### PR TITLE
feat: add Brainrun mode (boss fights + foundations)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/BRAINRUN_ROADMAP.md
+++ b/BRAINRUN_ROADMAP.md
@@ -1,0 +1,63 @@
+# Brainrun — Roadmap & Checklist
+
+Mode roguelite solo, indépendant du mode Ascension existant (qui reste inchangé et caché du menu). Développement découpé en 4 phases.
+
+## Phase 1 — Fondations ✅ Terminée (commit `0d19c60`)
+
+- [x] Modèle de données : `BrainrunRun` / `BrainrunRoom` (Prisma), migration `20260702182116_add_brainrun` appliquée en base
+- [x] Types partagés (`shared/brainrun.ts`, `shared/DTO/brainrunResponseDTO.ts`)
+- [x] Constantes économie/difficulté (`server/utils/brainrunConfig.ts`)
+- [x] Algorithme de génération des points de choix par acte, avec quotas (≥50% Standard/Elite pur, ≥1 Boutique, ≥1 Repos, ≥2 Événement) — `server/utils/brainrunLogic.ts`
+- [x] Sélection de questions par difficulté sans répétition (`QuestionService.getRandomIdsByDifficulty`)
+- [x] `BrainrunService` : démarrage/reprise de run, résolution des choix, soumission des réponses, avancement acte/salle, fin de run (XP + achievements)
+- [x] Endpoints API (`current`, `answer`, `choice`, `acknowledge`, `new`, `abandon`)
+- [x] Composable `useBrainrunSession`
+- [x] Composant `BrainrunQuestionRunner` (dédié, ne touche pas à `QuestionSeries.vue`)
+- [x] Page `brainrun.vue` : écran de connexion, HUD (acte/PV/or), écran de choix, placeholder Boutique/Événement, **récap de fin de salle (or gagné / PV perdus)**, écran de fin de run
+- [x] Entrée de navigation + route `ssr: false`
+- [x] Tests unitaires sur la logique pure (`brainrunLogic.test.ts`)
+- [x] Bug corrigé : une salle ne se terminait jamais si la dernière question était ratée sans mourir
+- [x] Bug corrigé : la page plantait sur l'écran d'erreur 401 de Nuxt au lieu d'afficher l'écran de connexion
+
+### Limites connues / placeholders assumés en Phase 1
+
+- La salle **Boss** se comporte comme une Elite renforcée (pas de vrai mécanisme "contre-la-montre" — c'est la Phase 2)
+- **Boutique** et **Événement** n'ont aucun effet de jeu : juste un écran "en construction" puis la suite (vrai contenu en Phase 3)
+- Les valeurs d'XP par salle (`BRAINRUN_XP_BY_ROOM_TYPE`, bonus de victoire) sont des valeurs de départ non équilibrées par des tests réels
+- Pas de notification/toast pour les achievements Brainrun débloqués (ils sont bien attribués en base, juste pas remontés visuellement au joueur)
+- `vp test`/`vp check` n'ont pas pu être exécutés dans l'environnement de développement utilisé pour écrire le code (problème de résolution d'alias `#shared` propre à ce sandbox) — à confirmer en local
+
+## Phase 2 — Boss "Contre-la-montre" ✅ Terminée (migration `20260702190000_add_brainrun_boss_fight`)
+
+- [x] Modèle de données étendu : `BrainrunRoom.bossHealthPoint` / `bossMaxHealthPoint` / `questionStartedAt` (migration appliquée en base)
+- [x] Vrai mécanisme de boss : barre de PV (`BRAINRUN_BOSS_MAX_HP` = 5 × `BRAINRUN_BOSS_BASE_DAMAGE`), dégâts liés à la vitesse de réponse (x2 si réponse correcte en moins de 2s, `brainrunBossDamage` dans `server/utils/brainrunLogic.ts`)
+- [x] Chrono par question (10s, `BRAINRUN_BOSS_QUESTION_TIME_MS` dans `shared/brainrun.ts`) ; si le temps expire (`isBossAnswerTimedOut`), la réponse est forcée en échec côté serveur (le boss "riposte") quelle que soit la réponse envoyée par le client
+- [x] Le boss peut désormais mourir avant d'avoir épuisé toutes ses questions (salle `CLEARED` immédiatement, contre-la-montre gratifiant la rapidité) ; s'il survit à toutes les questions, la salle se termine comme avant (pas d'échec forcé)
+- [x] Résolution "Elite renforcée" remplacée par cette vraie logique dans `BrainrunService.submitAnswer`
+- [x] Chrono démarré uniquement quand le joueur a fini de lire le feedback de la question précédente, via un nouvel aller-retour dédié (`POST /api/brainrun/boss-ready`, `BrainrunService.prepareNextBossQuestion`, composable `readyNextBossQuestion`) — évite de décompter le temps de lecture du feedback à l'insu du joueur
+- [x] UI dédiée dans `BrainrunQuestionRunner.vue` : barre de vie du boss + barre de chrono visible, auto-soumission au timeout
+- [x] Tests unitaires sur `isBossAnswerTimedOut` / `brainrunBossDamage`
+
+### Limites connues / placeholders assumés en Phase 2
+
+- Les valeurs (dégâts de base, seuil "rapide", durée du chrono) sont des valeurs de départ non équilibrées par des tests de jeu réels
+- `vp test`/`vp check` exécutés avec succès (0 erreur ; le run direct de `vp test brainrunLogic` échoue toujours sur la résolution d'alias `#shared` propre à ce sandbox, problème déjà identifié en Phase 1 et reproductible aussi sur le code d'avant ces changements — à confirmer que `vp test` complet fonctionne en local)
+- Pas de feedback visuel dédié "coup critique" quand le bonus de vitesse s'applique (juste les PV du boss qui baissent plus vite)
+
+## Phase 3 — Build (reliques / consommables) + vrai contenu Boutique/Événement
+
+- [ ] Système de reliques passives (ex: Encyclopédie, Chronomètre Brisé, Spécialisation, Seconde Chance, Adrénaline)
+- [ ] Consommables/jokers (50/50, Appel à un ami, Bouclier)
+- [ ] Vraie Boutique : achat d'objets/reliques avec l'or accumulé (l'or est déjà suivi depuis la Phase 1, sans usage jusqu'ici)
+- [ ] Vrais Événements : choix narratifs avec effets (ex: sacrifier des PV pour bannir une catégorie de questions le reste de la run)
+- [ ] Écran de sélection de bonus après salle (3 choix aléatoires selon rareté)
+
+## Phase 4 — Metagame
+
+- [ ] Monnaie meta persistante (Points de Savoir) séparée de l'or de run
+- [ ] Arbre de talents permanent (ex: +1 PV de départ, meilleure chance de reliques rares, déblocage de thèmes/skins)
+- [ ] Écran d'arbre de talents accessible hors-run (menu principal)
+
+## Divers / non lié à Brainrun mais repéré en cours de route
+
+- [ ] `VAPID_PRIVATE_KEY` / `VAPID_PUBLIC_KEY` manquantes dans `.env` (notifications push, aucun impact sur Brainrun)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+Lazyculture is a Nuxt 4 (SSR) trivia/quiz platform ("plateforme compétitive de quiz et culture générale") with realtime multiplayer modes, XP/ranking systems, adventures, and PWA support. Backend runs on Nuxt's Nitro server with Prisma/PostgreSQL, and Supabase for auth.
+
+## Toolchain (Vite+)
+
+This project uses **Vite+** (`vp`), a unified toolchain wrapping Vite, Vitest, and Oxlint — not raw `vite`/`vitest`/`eslint` commands.
+
+- `vp install` — install dependencies (run after pulling remote changes).
+- `vp run dev` — start the Nuxt dev server.
+- `vp run build` — production build.
+- `vp check` — format, lint, and type-check (auto-fix runs on staged files via `vite.config.ts`).
+- `vp test` — run the Vitest suite (tests use `vite-plus/test` imports, e.g. `server/utils/rankHelper.test.ts`). Use standard Vitest CLI filters to target a single test, e.g. `vp test rankHelper`.
+- `vp env doctor` — diagnose toolchain/runtime issues.
+- `npm run typecheck` (`vue-tsc --noEmit`) also works standalone.
+
+Prisma (not wrapped by `vp`):
+
+- `npx prisma generate` — regenerate the Prisma client after schema changes.
+- `npx prisma migrate dev --name MigrationName` — create/apply a migration.
+
+Always run `vp check` and `vp test` before considering a change complete.
+
+## Architecture
+
+**Directory layout** (Nuxt 4 `app/` convention + Nitro `server/`):
+
+- `app/` — Vue frontend: `pages/`, `components/`, `composables/`, `stores/` (Pinia), `middleware/`, `layouts/`.
+- `server/api/**/*.{get,post}.ts` — Nitro API routes, grouped by domain (`battle-royale/`, `adventure/`, `ranking/`, `series/`, `theme/`, `question/`, `user/`, `follow/`, `notifications/`, `admin/`, `import/`).
+- `server/services/` — domain service classes (`QuestionService`, `SeriesService`, `RankingService`, `AdventureService`, etc.) that API routes delegate to.
+- `server/utils/` — server-only helpers: `prisma.ts` (Prisma client singleton), `auth.ts` (auth guards), `battleRoyaleManager.ts` / `showdownManager.ts` (in-memory match/session managers for realtime modes), `rankHelper.ts` / `showdownRankHelper.ts` (ranking/LP logic), `pushNotification.ts`, `achievementHelper.ts`, `userProgressHelper.ts`.
+- `shared/` — code isomorphic between client and server: DTOs (`shared/DTO/`), domain types (`question.ts`, `theme.ts`, `series.ts`), and `series/seriesAscension.ts`.
+- `prisma/schema.prisma` — single source of truth for the data model; `prisma/migrations/` holds generated migrations.
+
+**Auth flow**: `server/middleware/auth.ts` runs on every request, resolves the Supabase user via `serverSupabaseClient(event)`, and stores `event.context.user` / `event.context.supabaseClient`. Route handlers then call `getAuthenticatedUser(event)` / `getSupabaseClient(event)` from `server/utils/auth.ts` to enforce auth, `assertAdmin(userId)` for admin-only routes, or `assertApiKeyOrAdmin(event)` for routes callable both by admins and via `x-api-key`. Client-side route protection uses `app/middleware/admin.ts` and Nuxt route rules in `nuxt.config.ts` (several routes are forced `ssr: false`, e.g. `/admin/**`, `/adventure/**`, `/series/battle-royale`, `/series/showdown`).
+
+**Realtime multiplayer (Battle Royale / Showdown)**: no external pub/sub — `battleRoyaleManager.ts` / `showdownManager.ts` hold match state and connected clients in-memory on the Nitro server. Clients subscribe via Server-Sent Events (`server/api/battle-royale/events.get.ts` calls `createEventStream(event)` and registers a push callback with the manager); actions (join/ready/submit/emote) are separate POST endpoints that mutate manager state and broadcast to registered clients. Because state is in-memory, it does not survive multiple server instances/restarts — keep this in mind for any changes affecting scaling.
+
+**Ranking**: `rankHelper.ts` / `showdownRankHelper.ts` implement LP (league points) gain/loss and division/demotion protection logic per game mode; `BattleRoyaleRank` and `ShowdownRank` Prisma models store per-user standings separately from generic `UserProgress`/XP leveling.
+
+**Series game modes** (`app/pages/series/`: `daily.vue`, `battle-royale.vue`, `showdown.vue`, `ascent.vue`): variants built on the generic `QuestionSeries` / `QuestionSeriesResponse` Prisma models served through `SeriesService`. Mode-specific data lives in the generic `data: Json` field, typed per mode in `shared/series/*.ts` (e.g. `shared/series/seriesAscension.ts` extends the base series/response types with `healthPoint` and an `ended` flag for the "Ascension" roguelite-style mode: sequential questions, lose a life on each wrong answer, run ends at 0 HP).
+
+**Adventures**: sequential stage-based content (`AdventureStage.type` = `STEP`/`CONTROL`/`EXAM`) tracked per user via `UserAdventureProgress` (`currentStage`, `completed`, `stageScores`).
+
+**Notifications**: `Notification` + `PushSubscription` Prisma models, driven by `server/utils/pushNotification.ts` (web-push) and surfaced client-side via `app/stores/notificationStore.ts`.
+
+**PWA**: configured via `@vite-pwa/nuxt` in `nuxt.config.ts` (manifest, workbox, `public/sw-push.js` import for push notifications); `app/components/pwa/` and `app/composables/usePwaInstall.ts` / `usePushSubscription.ts` handle install/subscribe UX.
+
+## Conventions
+
+- Path aliases: `~~/` refers to the project root (used for `server/` and `shared/` imports from anywhere, including server code).
+- UI copy and code comments are predominantly in French; match this when editing existing files.
+- Prefer delegating business logic from `server/api/**` route handlers into the corresponding `server/services/*Service.ts` class rather than inlining it in the handler.

--- a/app/components/brainrun/BrainrunQuestionRunner.vue
+++ b/app/components/brainrun/BrainrunQuestionRunner.vue
@@ -1,0 +1,238 @@
+<template>
+  <div
+    ref="containerRef"
+    class="relative w-full flex flex-col justify-center select-none min-h-0 transition-all duration-300"
+    :style="{ paddingBottom: `${actionBarHeight + 12}px` }"
+    v-if="localQuestion"
+  >
+    <QuestionDisplay
+      v-if="localQuestion"
+      ref="questionDisplay"
+      :libelle="localQuestion.data.libelle"
+      :img="localQuestion.data.img"
+      :themes="localQuestion.themes"
+      :propositions="localQuestion.data.propositions"
+      :disabled="responded"
+      :selectedOptionId="selectedResponse"
+      :correctOptionId="greenResponse"
+      :incorrectOptionId="redResponse"
+      :showCorrectIncorrectColors="responded"
+      :showReporting="true"
+      :questionId="localQuestion.id"
+      @selectOption="selectOption"
+    />
+
+    <!-- Sticky Bottom Bar (Duolingo Style - Unified Validate & Continue Action) -->
+    <div
+      ref="actionBarRef"
+      class="fixed bottom-0 left-0 right-0 z-50 border-t backdrop-blur-2xl shadow-2xl flex flex-col p-4 md:p-6 pb-[calc(1rem+env(safe-area-inset-bottom))] md:pb-[calc(1.5rem+env(safe-area-inset-bottom))] transition-all duration-300"
+      :class="
+        responded
+          ? isCorrect
+            ? 'bg-emerald-950/95 border-emerald-500/30 shadow-emerald-500/10 animate-slide-up'
+            : 'bg-rose-950/95 border-rose-500/30 shadow-rose-500/10 animate-slide-up'
+          : 'bg-slate-950/80 border-white/10'
+      "
+    >
+      <div class="max-w-xl mx-auto w-full flex flex-col">
+        <div class="w-full">
+          <div v-if="responded" class="flex items-start space-x-3 md:space-x-4">
+            <div
+              class="w-9 h-9 md:w-11 md:h-11 rounded-full flex items-center justify-center text-lg md:text-xl flex-shrink-0"
+              :class="
+                isCorrect
+                  ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-400/30'
+                  : 'bg-rose-500/20 text-rose-400 border border-rose-400/30'
+              "
+            >
+              <UIcon v-if="isCorrect" name="i-heroicons-check-circle" />
+              <UIcon v-else name="i-heroicons-exclamation-triangle" />
+            </div>
+            <div class="space-y-0.5 min-w-0 flex-1">
+              <h4
+                class="font-black font-display text-base tracking-wide flex items-center justify-between"
+                :class="isCorrect ? 'text-emerald-400' : 'text-rose-400'"
+              >
+                <span>{{ isCorrect ? "Bravo !" : "Incorrect" }}</span>
+              </h4>
+              <div
+                class="max-h-[20dvh] md:max-h-28 overflow-y-auto pr-2 custom-scrollbar select-text mb-3"
+              >
+                <p class="text-[13px] text-gray-300 font-medium leading-relaxed">
+                  {{
+                    commentaire ||
+                    (isCorrect ? "C'est exact !" : "Dommage ! Ouvrez l'œil pour la suite.")
+                  }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="w-full flex justify-center">
+          <UButton
+            v-if="!responded"
+            size="lg"
+            class="w-full font-black font-display uppercase tracking-widest py-2.5 md:py-3.5 justify-center shadow-lg"
+            :color="selectedResponse != null ? 'primary' : 'neutral'"
+            :disabled="selectedResponse == null || loading"
+            :loading="loading"
+            @click="validateResponse"
+          >
+            Valider
+          </UButton>
+          <UButton
+            v-else
+            size="lg"
+            class="w-full font-black font-display uppercase tracking-widest py-2.5 md:py-3.5 justify-center shadow-lg"
+            :color="isCorrect ? 'success' : 'error'"
+            @click="nextQuestion"
+          >
+            Continuer
+          </UButton>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { QuestionDTO } from "#shared/question";
+
+const props = defineProps<{
+  question: QuestionDTO | null;
+}>();
+
+const emit = defineEmits<{
+  advanced: [];
+}>();
+
+const brainrun = useBrainrunSession();
+const showBottomNav = useState("showBottomNav", () => true);
+
+const loading = ref(false);
+const commentaire = ref("");
+const responded = ref(false);
+const selectedResponse = ref<number | null>(null);
+const redResponse = ref<number | null>(null);
+const greenResponse = ref<number | null>(null);
+const questionDisplay = ref<any>(null);
+const containerRef = ref<HTMLElement | null>(null);
+const actionBarRef = ref<HTMLElement | null>(null);
+
+// Snapshot local de la question affichée : protège l'affichage du feedback (couleurs,
+// commentaire) du fait que useBrainrunSession().currentQuestion avance déjà vers la
+// question suivante dès la réponse au serveur (submitAnswer renvoie l'état complet
+// en un seul aller-retour). Le prop ne doit être appliqué qu'une fois "Continuer" cliqué.
+const localQuestion = ref<QuestionDTO | null>(props.question);
+
+watch(
+  () => props.question,
+  (newQuestion) => {
+    if (!responded.value) {
+      localQuestion.value = newQuestion;
+    }
+  },
+);
+
+const actionBarHeight = ref(96);
+let actionBarObserver: ResizeObserver | null = null;
+
+onMounted(() => {
+  showBottomNav.value = false;
+  if (actionBarRef.value) {
+    actionBarObserver = new ResizeObserver(() => {
+      actionBarHeight.value = actionBarRef.value?.offsetHeight ?? 96;
+    });
+    actionBarObserver.observe(actionBarRef.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  showBottomNav.value = true;
+  actionBarObserver?.disconnect();
+});
+
+async function scrollFeedbackIntoView() {
+  await nextTick();
+  if (actionBarRef.value) actionBarHeight.value = actionBarRef.value.offsetHeight;
+  await nextTick();
+  containerRef.value?.scrollIntoView({ block: "end", behavior: "smooth" });
+}
+
+const isCorrect = computed(() => {
+  return greenResponse.value === redResponse.value
+    ? false
+    : greenResponse.value !== null && redResponse.value === null;
+});
+
+function selectOption(id: number) {
+  if (responded.value) return;
+  selectedResponse.value = id;
+}
+
+async function validateResponse() {
+  const question = localQuestion.value;
+  if (selectedResponse.value == null || !question) return;
+  try {
+    loading.value = true;
+    commentaire.value = question.data.commentaire;
+
+    const isAnswerCorrect = selectedResponse.value === question.data.response;
+    if (isAnswerCorrect) {
+      greenResponse.value = selectedResponse.value;
+      redResponse.value = null;
+      const { playSound } = useAudio();
+      playSound("response-success");
+    } else {
+      redResponse.value = selectedResponse.value;
+      greenResponse.value = question.data.response;
+    }
+
+    // Fixé avant l'appel réseau : le watcher ci-dessus ignore alors le nouveau
+    // currentQuestion que submitAnswer va déclencher pendant qu'on montre le feedback.
+    responded.value = true;
+    await brainrun.submitAnswer(question.id, selectedResponse.value);
+    scrollFeedbackIntoView();
+  } catch (e) {
+    console.error("Failed to submit brainrun answer:", e);
+    responded.value = false;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function nextQuestion() {
+  responded.value = false;
+  commentaire.value = "";
+  selectedResponse.value = null;
+  redResponse.value = null;
+  greenResponse.value = null;
+  questionDisplay.value?.resetReporting();
+
+  localQuestion.value = props.question;
+  emit("advanced");
+
+  await nextTick();
+  containerRef.value?.scrollIntoView({ block: "start" });
+}
+</script>
+
+<style scoped>
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}
+
+.animate-shake {
+  animation: shake 0.2s ease-in-out 2;
+}
+</style>

--- a/app/components/brainrun/BrainrunQuestionRunner.vue
+++ b/app/components/brainrun/BrainrunQuestionRunner.vue
@@ -98,6 +98,7 @@
 
 <script setup lang="ts">
 import type { QuestionDTO } from "#shared/question";
+import { BRAINRUN_BOSS_QUESTION_TIME_MS } from "#shared/brainrun";
 
 const props = defineProps<{
   question: QuestionDTO | null;
@@ -109,6 +110,11 @@ const emit = defineEmits<{
 
 const brainrun = useBrainrunSession();
 const showBottomNav = useState("showBottomNav", () => true);
+// Signale à la page parente de garder cet écran affiché tant que le feedback de la
+// dernière question d'une salle est visible, même si l'état serveur (currentQuestion/
+// isRunActive) a déjà basculé vers la salle/run suivante — la transition visuelle
+// n'a lieu qu'au clic sur "Continuer" (cf. nextQuestion()).
+const holdOnFeedback = useState("brainrun-hold-on-feedback", () => false);
 
 const loading = ref(false);
 const commentaire = ref("");
@@ -119,6 +125,41 @@ const greenResponse = ref<number | null>(null);
 const questionDisplay = ref<any>(null);
 const containerRef = ref<HTMLElement | null>(null);
 const actionBarRef = ref<HTMLElement | null>(null);
+
+// Combat de boss (contre-la-montre) : chrono par question, dérivé de brainrun.currentRoom
+// (mis à jour par le serveur, seule source de vérité du temps restant). Partagé via useState
+// avec la page parente, qui affiche la barre de PV du boss + les dégâts potentiels à partir
+// de cette même valeur (à la place du séparateur habituel entre l'en-tête et la question).
+const timedOutFlag = ref(false);
+const remainingMs = useState("brainrun-boss-remaining-ms", () => BRAINRUN_BOSS_QUESTION_TIME_MS);
+let bossTimerInterval: ReturnType<typeof setInterval> | null = null;
+
+const isBossRoom = computed(() => brainrun.currentRoom.value?.type === "BOSS");
+
+function updateRemainingMs() {
+  const deadline = brainrun.currentRoom.value?.questionDeadline;
+  remainingMs.value = deadline
+    ? Math.max(0, new Date(deadline).getTime() - Date.now())
+    : BRAINRUN_BOSS_QUESTION_TIME_MS;
+}
+
+function stopBossTimer() {
+  if (bossTimerInterval) clearInterval(bossTimerInterval);
+  bossTimerInterval = null;
+}
+
+function startBossTimerIfNeeded() {
+  stopBossTimer();
+  // Pas de question à afficher (salle terminée, écran de récap/fin à venir) : rien à chronométrer.
+  if (!isBossRoom.value || !localQuestion.value) return;
+  updateRemainingMs();
+  bossTimerInterval = setInterval(() => {
+    updateRemainingMs();
+    if (remainingMs.value <= 0 && !responded.value) {
+      handleBossTimeout();
+    }
+  }, 200);
+}
 
 // Snapshot local de la question affichée : protège l'affichage du feedback (couleurs,
 // commentaire) du fait que useBrainrunSession().currentQuestion avance déjà vers la
@@ -146,11 +187,14 @@ onMounted(() => {
     });
     actionBarObserver.observe(actionBarRef.value);
   }
+  startBossTimerIfNeeded();
 });
 
 onBeforeUnmount(() => {
   showBottomNav.value = true;
+  holdOnFeedback.value = false;
   actionBarObserver?.disconnect();
+  stopBossTimer();
 });
 
 async function scrollFeedbackIntoView() {
@@ -161,6 +205,7 @@ async function scrollFeedbackIntoView() {
 }
 
 const isCorrect = computed(() => {
+  if (timedOutFlag.value) return false;
   return greenResponse.value === redResponse.value
     ? false
     : greenResponse.value !== null && redResponse.value === null;
@@ -192,29 +237,76 @@ async function validateResponse() {
     // Fixé avant l'appel réseau : le watcher ci-dessus ignore alors le nouveau
     // currentQuestion que submitAnswer va déclencher pendant qu'on montre le feedback.
     responded.value = true;
+    holdOnFeedback.value = true;
+    stopBossTimer();
     await brainrun.submitAnswer(question.id, selectedResponse.value);
     scrollFeedbackIntoView();
   } catch (e) {
     console.error("Failed to submit brainrun answer:", e);
     responded.value = false;
+    holdOnFeedback.value = false;
   } finally {
     loading.value = false;
   }
 }
 
+/** Contre-la-montre : le temps imparti à la question de boss en cours est écoulé. */
+async function handleBossTimeout() {
+  if (responded.value) return;
+  const question = localQuestion.value;
+  if (!question) return;
+  stopBossTimer();
+  commentaire.value = question.data.commentaire;
+  redResponse.value = null;
+  greenResponse.value = question.data.response;
+  timedOutFlag.value = true;
+  responded.value = true;
+  holdOnFeedback.value = true;
+  try {
+    // -1 : sentinelle "aucune réponse", le serveur force de toute façon l'échec au vu du délai écoulé.
+    await brainrun.submitAnswer(question.id, selectedResponse.value ?? -1);
+    scrollFeedbackIntoView();
+  } catch (e) {
+    console.error("Failed to submit brainrun boss timeout:", e);
+    responded.value = false;
+    timedOutFlag.value = false;
+    holdOnFeedback.value = false;
+  }
+}
+
 async function nextQuestion() {
+  // Levé dès le clic : si une question suivante existe, currentQuestion reste de toute
+  // façon truthy côté parent ; sinon (salle terminée), c'est ce flag qui autorisait
+  // encore l'affichage — sa levée déclenche enfin la transition vers le récap/l'écran de fin.
+  holdOnFeedback.value = false;
   responded.value = false;
   commentaire.value = "";
   selectedResponse.value = null;
   redResponse.value = null;
   greenResponse.value = null;
+  timedOutFlag.value = false;
   questionDisplay.value?.resetReporting();
 
-  localQuestion.value = props.question;
+  // Démarre le chrono de la question de boss suivante seulement maintenant que le joueur
+  // a fini de lire le feedback précédent (cf. commentaire côté serveur dans submitAnswer).
+  if (
+    isBossRoom.value &&
+    !brainrun.currentRoom.value?.questionDeadline &&
+    brainrun.currentQuestion.value
+  ) {
+    await brainrun.readyNextBossQuestion();
+    // brainrun.currentQuestion est la même ref partagée que le prop "question" du parent :
+    // on la lit directement pour éviter de dépendre du timing de propagation du prop après cet await.
+    localQuestion.value = brainrun.currentQuestion.value;
+  } else {
+    localQuestion.value = props.question;
+  }
   emit("advanced");
 
   await nextTick();
   containerRef.value?.scrollIntoView({ block: "start" });
+
+  startBossTimerIfNeeded();
 }
 </script>
 

--- a/app/composables/useBrainrunSession.ts
+++ b/app/composables/useBrainrunSession.ts
@@ -66,6 +66,18 @@ export const useBrainrunSession = () => {
     }
   }
 
+  /** Démarre le chrono de la question de boss suivante ; à appeler une fois le feedback lu. */
+  async function readyNextBossQuestion() {
+    if (!run.value) return;
+    const { authFetch } = useAuthFetch();
+    applyState(
+      await authFetch<BrainrunStateDTO>("/api/brainrun/boss-ready", {
+        method: "post",
+        body: { runId: run.value.id },
+      }),
+    );
+  }
+
   async function acknowledgeRoom() {
     if (!run.value) return;
     const { authFetch } = useAuthFetch();
@@ -116,6 +128,7 @@ export const useBrainrunSession = () => {
     fetchCurrent,
     submitAnswer,
     chooseOption,
+    readyNextBossQuestion,
     acknowledgeRoom,
     startNewRun,
     abandonRun,

--- a/app/composables/useBrainrunSession.ts
+++ b/app/composables/useBrainrunSession.ts
@@ -1,0 +1,124 @@
+import { computed } from "vue";
+import type { QuestionDTO } from "#shared/question";
+import type {
+  BrainrunRoomDTO,
+  BrainrunRoomType,
+  BrainrunRunDTO,
+  BrainrunStateDTO,
+} from "#shared/brainrun";
+
+/** État de session Brainrun : solo, tour par tour, pas de SSE — un simple fetch authentifié suffit. */
+export const useBrainrunSession = () => {
+  const run = useState<BrainrunRunDTO | null>("brainrun-run", () => null);
+  const currentRoom = useState<BrainrunRoomDTO | null>("brainrun-room", () => null);
+  const currentQuestion = useState<QuestionDTO | null>("brainrun-question", () => null);
+  const awaitingChoice = useState<boolean>("brainrun-awaiting-choice", () => false);
+  const loading = useState<boolean>("brainrun-loading", () => false);
+
+  const isRunActive = computed(() => run.value?.status === "IN_PROGRESS");
+  const isRunEnded = computed(() => !!run.value && run.value.status !== "IN_PROGRESS");
+
+  function applyState(state: BrainrunStateDTO) {
+    run.value = state.run;
+    currentRoom.value = state.currentRoom;
+    currentQuestion.value = state.currentQuestion;
+    awaitingChoice.value = state.awaitingChoice;
+  }
+
+  async function fetchCurrent() {
+    const { authFetch } = useAuthFetch();
+    loading.value = true;
+    try {
+      applyState(await authFetch<BrainrunStateDTO>("/api/brainrun/current"));
+    } catch (e) {
+      // Non authentifié ou erreur transitoire : on laisse l'état à null, la page
+      // affiche alors son propre écran (connexion / chargement) plutôt que de planter.
+      console.error("Failed to fetch brainrun state:", e);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function submitAnswer(questionId: number, userResponseId: number) {
+    if (!run.value) return;
+    const { authFetch } = useAuthFetch();
+    const state = await authFetch<BrainrunStateDTO>("/api/brainrun/answer", {
+      method: "post",
+      body: { runId: run.value.id, questionId, userResponseId },
+    });
+    applyState(state);
+    return state;
+  }
+
+  async function chooseOption(choice: BrainrunRoomType) {
+    if (!run.value) return;
+    const { authFetch } = useAuthFetch();
+    loading.value = true;
+    try {
+      applyState(
+        await authFetch<BrainrunStateDTO>("/api/brainrun/choice", {
+          method: "post",
+          body: { runId: run.value.id, choice },
+        }),
+      );
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function acknowledgeRoom() {
+    if (!run.value) return;
+    const { authFetch } = useAuthFetch();
+    loading.value = true;
+    try {
+      applyState(
+        await authFetch<BrainrunStateDTO>("/api/brainrun/acknowledge", {
+          method: "post",
+          body: { runId: run.value.id },
+        }),
+      );
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function startNewRun() {
+    const { authFetch } = useAuthFetch();
+    loading.value = true;
+    try {
+      applyState(await authFetch<BrainrunStateDTO>("/api/brainrun/new", { method: "post" }));
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function abandonRun() {
+    const { authFetch } = useAuthFetch();
+    await authFetch("/api/brainrun/abandon", { method: "post" });
+    reset();
+  }
+
+  function reset() {
+    run.value = null;
+    currentRoom.value = null;
+    currentQuestion.value = null;
+    awaitingChoice.value = false;
+  }
+
+  return {
+    run,
+    currentRoom,
+    currentQuestion,
+    awaitingChoice,
+    loading,
+    isRunActive,
+    isRunEnded,
+    fetchCurrent,
+    submitAnswer,
+    chooseOption,
+    acknowledgeRoom,
+    startNewRun,
+    abandonRun,
+    reset,
+  };
+};

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -73,7 +73,7 @@ const navItems = computed(() => [
   { label: "Aventures", path: "/adventure", icon: "i-heroicons-map" },
   { label: "Quotidien", path: "/series/daily", icon: "i-heroicons-calendar" },
   // { label: "Ascension", path: "/series/ascent", icon: "i-heroicons-arrow-trending-up" },
-  { label: "Brainrun", path: "/series/brainrun", icon: "i-heroicons-bolt" },
+  // { label: "Brainrun", path: "/series/brainrun", icon: "i-heroicons-bolt" },
   { label: "Multijoueur", path: "/multiplayer", icon: "i-heroicons-users" },
   { label: "Classement", path: "/ranking", icon: "i-heroicons-chart-bar" },
 ]);

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -73,6 +73,7 @@ const navItems = computed(() => [
   { label: "Aventures", path: "/adventure", icon: "i-heroicons-map" },
   { label: "Quotidien", path: "/series/daily", icon: "i-heroicons-calendar" },
   // { label: "Ascension", path: "/series/ascent", icon: "i-heroicons-arrow-trending-up" },
+  { label: "Brainrun", path: "/series/brainrun", icon: "i-heroicons-bolt" },
   { label: "Multijoueur", path: "/multiplayer", icon: "i-heroicons-users" },
   { label: "Classement", path: "/ranking", icon: "i-heroicons-chart-bar" },
 ]);

--- a/app/pages/series/brainrun.vue
+++ b/app/pages/series/brainrun.vue
@@ -1,0 +1,380 @@
+<template>
+  <div class="w-full max-w-xl mx-auto py-2 select-none">
+    <UCard
+      class="shadow-glass bg-[#111827]/70 backdrop-blur-xl border border-white/10 rounded-2xl p-2"
+    >
+      <!-- Non-authenticated user view -->
+      <template v-if="!user">
+        <div class="text-center py-10 px-6 space-y-6">
+          <div
+            class="w-16 h-16 rounded-full bg-violet-500/10 border border-violet-500/20 flex items-center justify-center text-3xl text-violet-400 mx-auto animate-pulse"
+          >
+            🧠
+          </div>
+          <div class="space-y-2">
+            <h2 class="text-2xl font-black font-display text-white tracking-wide">Brainrun</h2>
+            <p class="text-sm text-gray-400 max-w-sm mx-auto">
+              Grimpez les 3 actes, affrontez les Elites et les Boss, et survivez le plus loin
+              possible. Connectez-vous pour jouer !
+            </p>
+          </div>
+          <UButton
+            to="/login"
+            color="primary"
+            size="lg"
+            block
+            icon="i-heroicons-key"
+            class="font-extrabold uppercase font-display tracking-wider py-3"
+          >
+            Se connecter et jouer
+          </UButton>
+        </div>
+      </template>
+
+      <!-- Authenticated player view -->
+      <template v-else>
+        <!-- Game Header (Act/Room progress, HP hearts, gold) -->
+        <div class="flex flex-col space-y-4 mb-6">
+          <div class="flex justify-between items-center">
+            <h2 class="text-xl font-black font-display text-white tracking-wide flex items-center">
+              <UIcon
+                name="i-heroicons-bolt-solid"
+                class="mr-2 text-violet-400 text-2xl animate-pulse"
+              />
+              Acte {{ run?.currentAct ?? 1 }}
+            </h2>
+
+            <div class="flex items-center space-x-3">
+              <div class="flex items-center text-amber-400 font-black font-display text-sm">
+                <UIcon name="i-heroicons-currency-dollar" class="mr-0.5" />
+                {{ run?.gold ?? 0 }}
+              </div>
+              <div class="flex items-center">
+                <UIcon
+                  v-for="hp in run?.maxHealthPoint ?? 3"
+                  :key="hp"
+                  name="i-heroicons-heart-solid"
+                  class="text-2xl transition-all duration-300 ml-1"
+                  :class="
+                    hp > (run?.healthPoint ?? 0)
+                      ? 'text-slate-700'
+                      : 'text-rose-500 animate-heart-pulse'
+                  "
+                />
+              </div>
+            </div>
+          </div>
+
+          <div class="space-y-1.5">
+            <div
+              class="w-full h-2 bg-slate-950/80 rounded-full border border-white/5 overflow-hidden relative shadow-inner"
+            >
+              <div
+                class="h-full bg-gradient-to-r from-violet-600 to-indigo-500 rounded-full transition-all duration-300 shadow-neon"
+                :style="{ width: `${((run?.currentSequence ?? 1) / roomsPerAct) * 100}%` }"
+              ></div>
+            </div>
+            <div class="flex justify-between text-xs font-bold font-display text-gray-400">
+              <span>Progression de l'acte</span>
+              <span>{{ run?.currentSequence ?? 1 }} / {{ roomsPerAct }}</span>
+            </div>
+          </div>
+        </div>
+
+        <hr class="border-white/5 my-5" />
+
+        <!-- Run active : choix ponctuel, question en cours, ou état de chargement -->
+        <template v-if="isRunActive">
+          <div class="py-4">
+            <!-- Placeholder Boutique/Événement -->
+            <div v-if="placeholderChoice" class="text-center py-10 px-6 space-y-6">
+              <div
+                class="w-16 h-16 rounded-full bg-white/5 border border-white/10 flex items-center justify-center text-3xl mx-auto"
+              >
+                🚧
+              </div>
+              <div class="space-y-1">
+                <h3 class="text-lg font-black font-display text-white tracking-wide">
+                  {{ roomTypeLabel(placeholderChoice) }} — en construction
+                </h3>
+                <p class="text-xs text-gray-400 max-w-sm mx-auto">
+                  Ce type de salle arrivera dans une prochaine mise à jour. Pour l'instant,
+                  poursuivez votre ascension !
+                </p>
+              </div>
+              <UButton
+                size="lg"
+                color="primary"
+                block
+                :loading="loading"
+                class="font-black font-display uppercase tracking-widest py-3.5"
+                @click="confirmPlaceholder"
+              >
+                Étape suivante
+              </UButton>
+            </div>
+
+            <!-- Écran de choix -->
+            <div v-else-if="awaitingChoice" class="space-y-3">
+              <p
+                class="text-center text-xs font-bold text-gray-400 uppercase tracking-wider font-display mb-4"
+              >
+                Choisissez la prochaine salle
+              </p>
+              <UButton
+                v-for="option in currentChoiceTypes"
+                :key="option"
+                size="lg"
+                block
+                variant="soft"
+                :loading="loading"
+                class="font-black font-display uppercase tracking-wide py-3.5 justify-start"
+                @click="selectChoice(option)"
+              >
+                <UIcon :name="roomTypeIcon(option)" class="mr-2 text-lg" />
+                {{ roomTypeLabel(option) }}
+              </UButton>
+            </div>
+
+            <!-- Question en cours -->
+            <BrainrunQuestionRunner v-else-if="currentQuestion" :question="currentQuestion" />
+
+            <!-- Récap de fin de salle (or gagné, PV perdus) -->
+            <div v-else-if="roomRecap" class="text-center py-8 px-6 space-y-6">
+              <div
+                class="w-16 h-16 rounded-full bg-emerald-500/10 border border-emerald-500/30 flex items-center justify-center text-3xl mx-auto"
+              >
+                <UIcon :name="roomTypeIcon(roomRecap.type)" class="text-emerald-400" />
+              </div>
+              <div class="space-y-1">
+                <h3 class="text-lg font-black font-display text-white tracking-wide">
+                  {{ roomTypeLabel(roomRecap.type) }} terminée
+                </h3>
+              </div>
+              <div class="grid grid-cols-2 gap-3 w-full max-w-sm mx-auto">
+                <div class="bg-white/5 border border-white/10 rounded-2xl p-3 text-center">
+                  <p class="text-xl font-black font-display text-amber-400">
+                    +{{ roomRecap.goldEarned }}
+                  </p>
+                  <p
+                    class="text-[9px] font-bold text-gray-500 uppercase tracking-wider font-display mt-0.5"
+                  >
+                    Or gagné
+                  </p>
+                </div>
+                <div class="bg-white/5 border border-white/10 rounded-2xl p-3 text-center">
+                  <p
+                    class="text-xl font-black font-display"
+                    :class="roomRecap.heartsLost > 0 ? 'text-rose-400' : 'text-emerald-400'"
+                  >
+                    {{
+                      roomRecap.heartsLost > 0
+                        ? `-${roomRecap.heartsLost}`
+                        : roomRecap.healed
+                          ? "+1"
+                          : "0"
+                    }}
+                  </p>
+                  <p
+                    class="text-[9px] font-bold text-gray-500 uppercase tracking-wider font-display mt-0.5"
+                  >
+                    {{ roomRecap.healed ? "PV regagnés" : "PV perdus" }}
+                  </p>
+                </div>
+              </div>
+              <UButton
+                size="lg"
+                color="primary"
+                block
+                :loading="loading"
+                class="font-black font-display uppercase tracking-widest py-3.5 max-w-sm mx-auto"
+                @click="brainrun.acknowledgeRoom()"
+              >
+                Continuer
+              </UButton>
+            </div>
+
+            <div v-else class="text-center py-10">
+              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl text-gray-500" />
+            </div>
+          </div>
+        </template>
+
+        <!-- Fin de run (victoire ou défaite) -->
+        <template v-else-if="run">
+          <div class="text-center py-4 md:py-6 px-4 space-y-4 flex flex-col items-center">
+            <div class="relative">
+              <div
+                class="absolute inset-0 blur-xl rounded-full scale-125"
+                :class="run.status === 'WON' ? 'bg-amber-500/20' : 'bg-rose-500/20'"
+              ></div>
+              <div
+                class="relative w-16 h-16 rounded-full flex items-center justify-center text-3xl border"
+                :class="
+                  run.status === 'WON'
+                    ? 'bg-amber-500/10 border-amber-500/30 text-amber-400'
+                    : 'bg-rose-500/10 border-rose-500/30 text-rose-400'
+                "
+              >
+                {{ run.status === "WON" ? "🏆" : "💀" }}
+              </div>
+            </div>
+
+            <div class="space-y-1">
+              <h3 class="text-xl font-black font-display text-white tracking-wide">
+                {{ run.status === "WON" ? "Run terminée !" : "Run échouée" }}
+              </h3>
+              <p class="text-xs text-gray-400 max-w-sm">
+                {{
+                  run.status === "WON"
+                    ? "Bravo, vous avez survécu aux 3 actes de Brainrun !"
+                    : "Vous avez épuisé tous vos points de vie. Retentez votre chance !"
+                }}
+              </p>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3 w-full max-w-sm pt-2">
+              <div class="bg-white/5 border border-white/10 rounded-2xl p-3 text-center">
+                <p class="text-xl font-black font-display text-amber-400">{{ run.gold }}</p>
+                <p
+                  class="text-[9px] font-bold text-gray-500 uppercase tracking-wider font-display mt-0.5"
+                >
+                  Or récolté
+                </p>
+              </div>
+              <div class="bg-white/5 border border-white/10 rounded-2xl p-3 text-center">
+                <p class="text-xl font-black font-display text-amber-400">
+                  +{{ run.xpEarned ?? 0 }} XP
+                </p>
+                <p
+                  class="text-[9px] font-bold text-gray-500 uppercase tracking-wider font-display mt-0.5"
+                >
+                  Expérience
+                </p>
+              </div>
+            </div>
+
+            <div class="pt-3 w-full max-w-sm">
+              <UButton
+                size="lg"
+                color="primary"
+                block
+                :loading="loading"
+                icon="i-heroicons-arrow-path"
+                class="font-black font-display uppercase tracking-widest py-3.5"
+                @click="brainrun.startNewRun()"
+              >
+                Nouvelle run
+              </UButton>
+            </div>
+          </div>
+        </template>
+      </template>
+    </UCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { BRAINRUN_ROOMS_PER_ACT, type BrainrunRoomType } from "#shared/brainrun";
+import { useUserStore } from "~/stores/userStore";
+
+const userStore = useUserStore();
+await userStore.fetchUser();
+const user = computed(() => userStore.user);
+
+const brainrun = useBrainrunSession();
+const showBottomNav = useState("showBottomNav", () => true);
+const placeholderChoice = ref<BrainrunRoomType | null>(null);
+
+const roomsPerAct = BRAINRUN_ROOMS_PER_ACT;
+
+if (user.value) {
+  await brainrun.fetchCurrent();
+}
+
+const run = brainrun.run;
+const currentQuestion = brainrun.currentQuestion;
+const awaitingChoice = brainrun.awaitingChoice;
+const loading = brainrun.loading;
+const isRunActive = brainrun.isRunActive;
+const currentChoiceTypes = computed(() => brainrun.currentRoom.value?.choiceTypes ?? []);
+
+const roomRecap = computed(() => {
+  const room = brainrun.currentRoom.value;
+  if (!room || room.status !== "CLEARED" || !room.type) return null;
+  const heartsLost = room.responses.reduce((sum, r) => sum + (r.hpLoss ?? 0), 0);
+  return {
+    type: room.type,
+    goldEarned: room.goldEarned,
+    heartsLost,
+    healed: room.type === "REST",
+  };
+});
+
+watch(
+  () => isRunActive.value && !awaitingChoice.value && !!currentQuestion.value,
+  (inQuestion) => {
+    showBottomNav.value = !inQuestion;
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  showBottomNav.value = true;
+});
+
+const INSTANT_TYPES: BrainrunRoomType[] = ["SHOP", "EVENT"];
+
+async function selectChoice(option: BrainrunRoomType) {
+  if (INSTANT_TYPES.includes(option)) {
+    placeholderChoice.value = option;
+    return;
+  }
+  await brainrun.chooseOption(option);
+}
+
+async function confirmPlaceholder() {
+  if (!placeholderChoice.value) return;
+  const choice = placeholderChoice.value;
+  placeholderChoice.value = null;
+  await brainrun.chooseOption(choice);
+}
+
+function roomTypeLabel(type: BrainrunRoomType): string {
+  switch (type) {
+    case "STANDARD":
+      return "Combat";
+    case "ELITE":
+      return "Elite";
+    case "BOSS":
+      return "Boss";
+    case "REST":
+      return "Repos (+1 PV)";
+    case "SHOP":
+      return "Boutique";
+    case "EVENT":
+      return "Événement";
+  }
+}
+
+function roomTypeIcon(type: BrainrunRoomType): string {
+  switch (type) {
+    case "STANDARD":
+      return "i-heroicons-bolt";
+    case "ELITE":
+      return "i-heroicons-fire";
+    case "BOSS":
+      return "i-heroicons-shield-exclamation";
+    case "REST":
+      return "i-heroicons-heart";
+    case "SHOP":
+      return "i-heroicons-shopping-bag";
+    case "EVENT":
+      return "i-heroicons-question-mark-circle";
+  }
+}
+</script>
+
+<style scoped>
+/* Page-specific styles if any */
+</style>

--- a/app/pages/series/brainrun.vue
+++ b/app/pages/series/brainrun.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="w-full max-w-xl mx-auto py-2 select-none">
     <UCard
-      class="shadow-glass bg-[#111827]/70 backdrop-blur-xl border border-white/10 rounded-2xl p-2"
+      class="shadow-glass bg-[#111827]/70 backdrop-blur-xl border border-white/10 rounded-2xl"
+      :ui="{ body: 'p-2' }"
     >
       <!-- Non-authenticated user view -->
       <template v-if="!user">
@@ -34,8 +35,8 @@
       <!-- Authenticated player view -->
       <template v-else>
         <!-- Game Header (Act/Room progress, HP hearts, gold) -->
-        <div class="flex flex-col space-y-4 mb-6">
-          <div class="flex justify-between items-center">
+        <div class="flex justify-between items-center mb-4">
+          <div class="flex items-center gap-2">
             <h2 class="text-xl font-black font-display text-white tracking-wide flex items-center">
               <UIcon
                 name="i-heroicons-bolt-solid"
@@ -43,49 +44,66 @@
               />
               Acte {{ run?.currentAct ?? 1 }}
             </h2>
-
-            <div class="flex items-center space-x-3">
-              <div class="flex items-center text-amber-400 font-black font-display text-sm">
-                <UIcon name="i-heroicons-currency-dollar" class="mr-0.5" />
-                {{ run?.gold ?? 0 }}
-              </div>
-              <div class="flex items-center">
-                <UIcon
-                  v-for="hp in run?.maxHealthPoint ?? 3"
-                  :key="hp"
-                  name="i-heroicons-heart-solid"
-                  class="text-2xl transition-all duration-300 ml-1"
-                  :class="
-                    hp > (run?.healthPoint ?? 0)
-                      ? 'text-slate-700'
-                      : 'text-rose-500 animate-heart-pulse'
-                  "
-                />
-              </div>
-            </div>
+            <span
+              class="text-xs font-bold font-display text-gray-400 bg-white/5 border border-white/10 rounded-full px-2 py-0.5"
+            >
+              {{ run?.currentSequence ?? 1 }} / {{ roomsPerAct }}
+            </span>
           </div>
 
-          <div class="space-y-1.5">
-            <div
-              class="w-full h-2 bg-slate-950/80 rounded-full border border-white/5 overflow-hidden relative shadow-inner"
-            >
-              <div
-                class="h-full bg-gradient-to-r from-violet-600 to-indigo-500 rounded-full transition-all duration-300 shadow-neon"
-                :style="{ width: `${((run?.currentSequence ?? 1) / roomsPerAct) * 100}%` }"
-              ></div>
+          <div class="flex items-center space-x-3">
+            <div class="flex items-center text-amber-400 font-black font-display text-sm">
+              <UIcon name="i-heroicons-currency-dollar" class="mr-0.5" />
+              {{ run?.gold ?? 0 }}
             </div>
-            <div class="flex justify-between text-xs font-bold font-display text-gray-400">
-              <span>Progression de l'acte</span>
-              <span>{{ run?.currentSequence ?? 1 }} / {{ roomsPerAct }}</span>
+            <div class="flex items-center">
+              <UIcon
+                v-for="hp in run?.maxHealthPoint ?? 3"
+                :key="hp"
+                name="i-heroicons-heart-solid"
+                class="text-2xl transition-all duration-300 ml-1"
+                :class="
+                  hp > (run?.healthPoint ?? 0)
+                    ? 'text-slate-700'
+                    : 'text-rose-500 animate-heart-pulse'
+                "
+              />
             </div>
           </div>
         </div>
 
-        <hr class="border-white/5 my-5" />
+        <!-- Combat de boss : remplace le séparateur habituel par la barre de PV du boss +
+             les dégâts qu'infligerait une réponse correcte à cet instant (décroissants). -->
+        <div v-if="isBossRoom" class="flex items-center gap-2 mt-3">
+          <UIcon name="i-heroicons-shield-exclamation" class="text-rose-400 text-base shrink-0" />
+          <div
+            class="flex-1 h-2.5 bg-slate-950/80 rounded-full border border-white/5 overflow-hidden shadow-inner"
+          >
+            <div
+              class="h-full bg-gradient-to-r from-rose-600 to-orange-500 rounded-full transition-all duration-500"
+              :style="{ width: `${bossHealthPercent}%` }"
+            ></div>
+          </div>
+          <span class="text-[11px] font-bold text-gray-400 font-display shrink-0">
+            {{ bossHealthPoint }}/{{ bossMaxHealthPoint }}
+          </span>
+          <span
+            v-if="currentRoom?.status === 'ACTIVE'"
+            class="flex items-center gap-0.5 text-xs font-black font-display shrink-0 tabular-nums"
+            :class="potentialDamage > 0 ? 'text-amber-400' : 'text-rose-400 animate-pulse'"
+          >
+            <UIcon name="i-heroicons-bolt" />
+            -{{ potentialDamage }}
+          </span>
+        </div>
+        <hr v-else class="border-white/5 my-3" />
 
-        <!-- Run active : choix ponctuel, question en cours, ou état de chargement -->
-        <template v-if="isRunActive">
-          <div class="py-4">
+        <!-- Run active : choix ponctuel, question en cours, ou état de chargement.
+             holdOnFeedback maintient cet écran tant que BrainrunQuestionRunner affiche encore
+             le feedback de la dernière question (correct/incorrect), même si côté serveur la
+             salle est déjà CLEARED/FAILED — la transition n'a lieu qu'au clic sur "Continuer". -->
+        <template v-if="isRunActive || holdOnFeedback">
+          <div :class="isBossRoom ? 'pt-2 pb-4' : 'py-4'">
             <!-- Placeholder Boutique/Événement -->
             <div v-if="placeholderChoice" class="text-center py-10 px-6 space-y-6">
               <div
@@ -137,7 +155,10 @@
             </div>
 
             <!-- Question en cours -->
-            <BrainrunQuestionRunner v-else-if="currentQuestion" :question="currentQuestion" />
+            <BrainrunQuestionRunner
+              v-else-if="currentQuestion || holdOnFeedback"
+              :question="currentQuestion"
+            />
 
             <!-- Récap de fin de salle (or gagné, PV perdus) -->
             <div v-else-if="roomRecap" class="text-center py-8 px-6 space-y-6">
@@ -275,7 +296,12 @@
 </template>
 
 <script setup lang="ts">
-import { BRAINRUN_ROOMS_PER_ACT, type BrainrunRoomType } from "#shared/brainrun";
+import {
+  BRAINRUN_BOSS_QUESTION_TIME_MS,
+  BRAINRUN_ROOMS_PER_ACT,
+  brainrunPotentialBossDamage,
+  type BrainrunRoomType,
+} from "#shared/brainrun";
 import { useUserStore } from "~/stores/userStore";
 
 const userStore = useUserStore();
@@ -284,6 +310,10 @@ const user = computed(() => userStore.user);
 
 const brainrun = useBrainrunSession();
 const showBottomNav = useState("showBottomNav", () => true);
+// Piloté par BrainrunQuestionRunner : reste à true tant qu'il affiche encore le feedback
+// de la dernière question d'une salle, pour ne pas basculer vers le récap/l'écran de fin
+// tant que le joueur n'a pas cliqué sur "Continuer".
+const holdOnFeedback = useState("brainrun-hold-on-feedback", () => false);
 const placeholderChoice = ref<BrainrunRoomType | null>(null);
 
 const roomsPerAct = BRAINRUN_ROOMS_PER_ACT;
@@ -294,10 +324,27 @@ if (user.value) {
 
 const run = brainrun.run;
 const currentQuestion = brainrun.currentQuestion;
+const currentRoom = brainrun.currentRoom;
 const awaitingChoice = brainrun.awaitingChoice;
 const loading = brainrun.loading;
 const isRunActive = brainrun.isRunActive;
-const currentChoiceTypes = computed(() => brainrun.currentRoom.value?.choiceTypes ?? []);
+const currentChoiceTypes = computed(() => currentRoom.value?.choiceTypes ?? []);
+
+// Barre de PV du boss + dégâts potentiels (remplace le séparateur habituel pendant un combat
+// de boss) : le décompte est celui tenu par BrainrunQuestionRunner, partagé via useState.
+const isBossRoom = computed(() => currentRoom.value?.type === "BOSS");
+const bossHealthPoint = computed(() => currentRoom.value?.bossHealthPoint ?? 0);
+const bossMaxHealthPoint = computed(() => currentRoom.value?.bossMaxHealthPoint ?? 1);
+const bossHealthPercent = computed(() =>
+  Math.max(0, Math.min(100, (bossHealthPoint.value / bossMaxHealthPoint.value) * 100)),
+);
+const bossRemainingMs = useState(
+  "brainrun-boss-remaining-ms",
+  () => BRAINRUN_BOSS_QUESTION_TIME_MS,
+);
+const potentialDamage = computed(() =>
+  brainrunPotentialBossDamage(BRAINRUN_BOSS_QUESTION_TIME_MS - bossRemainingMs.value),
+);
 
 const roomRecap = computed(() => {
   const room = brainrun.currentRoom.value;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -127,6 +127,7 @@ export default defineNuxtConfig({
     "/adventure/**": { ssr: false },
     "/series/battle-royale": { ssr: false },
     "/series/showdown": { ssr: false },
+    "/series/brainrun": { ssr: false },
     "/login": { ssr: false },
     "/confirm": { ssr: false },
   },

--- a/prisma/migrations/20260702182116_add_brainrun/migration.sql
+++ b/prisma/migrations/20260702182116_add_brainrun/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "BrainrunRun" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'IN_PROGRESS',
+    "currentAct" INTEGER NOT NULL DEFAULT 1,
+    "currentSequence" INTEGER NOT NULL DEFAULT 1,
+    "healthPoint" INTEGER NOT NULL,
+    "maxHealthPoint" INTEGER NOT NULL,
+    "gold" INTEGER NOT NULL DEFAULT 0,
+    "usedQuestionIds" INTEGER[] DEFAULT ARRAY[]::INTEGER[],
+    "xpEarned" INTEGER,
+    "createDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updateDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "endDate" TIMESTAMP(3),
+
+    CONSTRAINT "BrainrunRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BrainrunRoom" (
+    "id" SERIAL NOT NULL,
+    "runId" TEXT NOT NULL,
+    "act" INTEGER NOT NULL,
+    "sequence" INTEGER NOT NULL,
+    "type" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "choiceTypes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "questionIds" INTEGER[] DEFAULT ARRAY[]::INTEGER[],
+    "responses" JSONB,
+    "goldEarned" INTEGER NOT NULL DEFAULT 0,
+    "createDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updateDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BrainrunRoom_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BrainrunRun_userId_idx" ON "BrainrunRun"("userId");
+
+-- CreateIndex
+CREATE INDEX "BrainrunRun_userId_status_idx" ON "BrainrunRun"("userId", "status");
+
+-- CreateIndex
+CREATE INDEX "BrainrunRoom_runId_idx" ON "BrainrunRoom"("runId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BrainrunRoom_runId_act_sequence_key" ON "BrainrunRoom"("runId", "act", "sequence");
+
+-- AddForeignKey
+ALTER TABLE "BrainrunRun" ADD CONSTRAINT "BrainrunRun_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BrainrunRoom" ADD CONSTRAINT "BrainrunRoom_runId_fkey" FOREIGN KEY ("runId") REFERENCES "BrainrunRun"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/migrations/20260702190000_add_brainrun_boss_fight/migration.sql
+++ b/prisma/migrations/20260702190000_add_brainrun_boss_fight/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "BrainrunRoom" ADD COLUMN     "bossHealthPoint" INTEGER,
+ADD COLUMN     "bossMaxHealthPoint" INTEGER,
+ADD COLUMN     "questionStartedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -310,19 +310,22 @@ model BrainrunRun {
 }
 
 model BrainrunRoom {
-    id          Int         @id @default(autoincrement())
-    runId       String
-    run         BrainrunRun @relation(fields: [runId], references: [id], onDelete: Cascade)
-    act         Int // 1..3
-    sequence    Int // 1..7 dans l'acte
-    type        String? // STANDARD, ELITE, BOSS, REST, SHOP, EVENT — null tant que le choix n'est pas fait
-    status      String      @default("PENDING") // PENDING, ACTIVE, CLEARED, FAILED, SKIPPED
-    choiceTypes String[]    @default([]) // types proposés au point de choix ayant mené à cette salle
-    questionIds Int[]       @default([])
-    responses   Json?
-    goldEarned  Int         @default(0)
-    createDate  DateTime    @default(now())
-    updateDate  DateTime    @default(now())
+    id                 Int         @id @default(autoincrement())
+    runId              String
+    run                BrainrunRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+    act                Int // 1..3
+    sequence           Int // 1..7 dans l'acte
+    type               String? // STANDARD, ELITE, BOSS, REST, SHOP, EVENT — null tant que le choix n'est pas fait
+    status             String      @default("PENDING") // PENDING, ACTIVE, CLEARED, FAILED, SKIPPED
+    choiceTypes        String[]    @default([]) // types proposés au point de choix ayant mené à cette salle
+    questionIds        Int[]       @default([])
+    responses          Json?
+    goldEarned         Int         @default(0)
+    bossHealthPoint    Int? // PV courants du boss, uniquement pour type=BOSS
+    bossMaxHealthPoint Int? // PV max du boss au démarrage du combat, uniquement pour type=BOSS
+    questionStartedAt  DateTime? // horodatage d'affichage de la question en attente, sert de base au chrono du combat de boss
+    createDate         DateTime    @default(now())
+    updateDate         DateTime    @default(now())
 
     @@unique([runId, act, sequence])
     @@index([runId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
     FollowNotifSent        FollowNotification[]     @relation("FollowNotifFollower")
     FollowNotifReceived    FollowNotification[]     @relation("FollowNotifFollowing")
     notifications          Notification[]
+    BrainrunRun            BrainrunRun[]
 }
 
 model Follow {
@@ -285,6 +286,46 @@ model UserAdventureProgress {
     updateDate  DateTime  @default(now())
 
     @@unique([userId, adventureId])
+}
+
+model BrainrunRun {
+    id              String         @id @default(uuid())
+    userId          String
+    user            User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+    status          String         @default("IN_PROGRESS") // IN_PROGRESS, WON, LOST, ABANDONED
+    currentAct      Int            @default(1) // 1..3
+    currentSequence Int            @default(1) // 1..7, pointeur vers l'emplacement actif
+    healthPoint     Int
+    maxHealthPoint  Int
+    gold            Int            @default(0)
+    usedQuestionIds Int[]          @default([]) // anti-répétition sur toute la run
+    xpEarned        Int?
+    createDate      DateTime       @default(now())
+    updateDate      DateTime       @default(now())
+    endDate         DateTime?
+    rooms           BrainrunRoom[]
+
+    @@index([userId])
+    @@index([userId, status])
+}
+
+model BrainrunRoom {
+    id          Int         @id @default(autoincrement())
+    runId       String
+    run         BrainrunRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+    act         Int // 1..3
+    sequence    Int // 1..7 dans l'acte
+    type        String? // STANDARD, ELITE, BOSS, REST, SHOP, EVENT — null tant que le choix n'est pas fait
+    status      String      @default("PENDING") // PENDING, ACTIVE, CLEARED, FAILED, SKIPPED
+    choiceTypes String[]    @default([]) // types proposés au point de choix ayant mené à cette salle
+    questionIds Int[]       @default([])
+    responses   Json?
+    goldEarned  Int         @default(0)
+    createDate  DateTime    @default(now())
+    updateDate  DateTime    @default(now())
+
+    @@unique([runId, act, sequence])
+    @@index([runId])
 }
 
 model PushSubscription {

--- a/server/api/brainrun/abandon.post.ts
+++ b/server/api/brainrun/abandon.post.ts
@@ -1,0 +1,8 @@
+import { brainrunService } from "~~/server/services/BrainrunService";
+import { getAuthenticatedUser } from "~~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const userConnected = getAuthenticatedUser(event);
+  await brainrunService.abandonRun(userConnected.id);
+  return { success: true };
+});

--- a/server/api/brainrun/acknowledge.post.ts
+++ b/server/api/brainrun/acknowledge.post.ts
@@ -1,0 +1,8 @@
+import { brainrunService } from "~~/server/services/BrainrunService";
+import { getAuthenticatedUser } from "~~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const userConnected = getAuthenticatedUser(event);
+  const body = await readBody<{ runId: string }>(event);
+  return brainrunService.acknowledgeRoom(body.runId, userConnected.id);
+});

--- a/server/api/brainrun/answer.post.ts
+++ b/server/api/brainrun/answer.post.ts
@@ -1,0 +1,14 @@
+import type { BrainrunResponseDTO } from "#shared/DTO/brainrunResponseDTO";
+import { brainrunService } from "~~/server/services/BrainrunService";
+import { getAuthenticatedUser } from "~~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const userConnected = getAuthenticatedUser(event);
+  const body = await readBody<BrainrunResponseDTO>(event);
+  return brainrunService.submitAnswer(
+    body.runId,
+    body.questionId,
+    body.userResponseId,
+    userConnected.id,
+  );
+});

--- a/server/api/brainrun/boss-ready.post.ts
+++ b/server/api/brainrun/boss-ready.post.ts
@@ -1,0 +1,8 @@
+import { brainrunService } from "~~/server/services/BrainrunService";
+import { getAuthenticatedUser } from "~~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const userConnected = getAuthenticatedUser(event);
+  const body = await readBody<{ runId: string }>(event);
+  return brainrunService.prepareNextBossQuestion(body.runId, userConnected.id);
+});

--- a/server/api/brainrun/choice.post.ts
+++ b/server/api/brainrun/choice.post.ts
@@ -1,0 +1,9 @@
+import type { BrainrunChoiceDTO } from "#shared/DTO/brainrunResponseDTO";
+import { brainrunService } from "~~/server/services/BrainrunService";
+import { getAuthenticatedUser } from "~~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const userConnected = getAuthenticatedUser(event);
+  const body = await readBody<BrainrunChoiceDTO>(event);
+  return brainrunService.chooseOption(body.runId, body.choice, userConnected.id);
+});

--- a/server/api/brainrun/current.get.ts
+++ b/server/api/brainrun/current.get.ts
@@ -1,0 +1,7 @@
+import { brainrunService } from "~~/server/services/BrainrunService";
+import { getAuthenticatedUser } from "~~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const userConnected = getAuthenticatedUser(event);
+  return brainrunService.getOrStartRun(userConnected.id);
+});

--- a/server/api/brainrun/new.post.ts
+++ b/server/api/brainrun/new.post.ts
@@ -1,0 +1,7 @@
+import { brainrunService } from "~~/server/services/BrainrunService";
+import { getAuthenticatedUser } from "~~/server/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const userConnected = getAuthenticatedUser(event);
+  return brainrunService.startNewRun(userConnected.id);
+});

--- a/server/services/BrainrunService.ts
+++ b/server/services/BrainrunService.ts
@@ -3,13 +3,17 @@ import { isCorrectAnswer, questionService } from "~~/server/services/QuestionSer
 import { updateUserProgress } from "~~/server/utils/userProgressHelper";
 import { checkAndAwardAchievements } from "~~/server/utils/achievementHelper";
 import {
+  brainrunBossDamage,
   brainrunHpLossForDifficulty,
   calculBrainrunUserXP,
   generateActChoicePoints,
   instantRoomHealthDelta,
+  isBossAnswerTimedOut,
   nextRoomAfterClear,
 } from "~~/server/utils/brainrunLogic";
 import {
+  BRAINRUN_BOSS_MAX_HP,
+  BRAINRUN_BOSS_QUESTION_TIME_MS,
   BRAINRUN_DIFFICULTY_BY_ACT,
   BRAINRUN_GOLD_BY_ROOM_TYPE,
   BRAINRUN_MAX_HP,
@@ -120,7 +124,9 @@ export class BrainrunService {
       const combatType = choice as CombatRoomType;
       const [minDifficulty, maxDifficulty] =
         BRAINRUN_DIFFICULTY_BY_ACT[run.currentAct]![combatType]!;
-      const count = BRAINRUN_QUESTIONS_PER_ROOM[combatType];
+      // Le combat de boss n'a pas de nombre de questions fixe : on n'en tire qu'une seule ici,
+      // les suivantes sont générées à la volée dans submitAnswer tant que le boss n'est pas à 0 PV.
+      const count = combatType === "BOSS" ? 1 : BRAINRUN_QUESTIONS_PER_ROOM[combatType];
       const questionIds = await questionService.getRandomIdsByDifficulty(
         minDifficulty,
         maxDifficulty,
@@ -131,7 +137,19 @@ export class BrainrunService {
 
       await prisma.brainrunRoom.update({
         where: { id: activeRoom.id },
-        data: { type: choice, status: "ACTIVE", questionIds, responses: [] },
+        data: {
+          type: choice,
+          status: "ACTIVE",
+          questionIds,
+          responses: [],
+          ...(combatType === "BOSS"
+            ? {
+                bossHealthPoint: BRAINRUN_BOSS_MAX_HP,
+                bossMaxHealthPoint: BRAINRUN_BOSS_MAX_HP,
+                questionStartedAt: new Date(),
+              }
+            : {}),
+        },
       });
       await prisma.brainrunRun.update({
         where: { id: run.id },
@@ -165,17 +183,37 @@ export class BrainrunService {
     }
 
     const question = await prisma.question.findFirstOrThrow({ where: { id: questionId } });
-    const success = isCorrectAnswer(question, userResponseId);
+    const isBossRoom = activeRoom.type === "BOSS";
+    const elapsedMs = activeRoom.questionStartedAt
+      ? Date.now() - activeRoom.questionStartedAt.getTime()
+      : 0;
+    // Contre-la-montre : passé le délai imparti, la réponse est forcée en échec, quelle
+    // que soit la proposition envoyée par le client (le boss riposte).
+    const timedOut = isBossRoom && isBossAnswerTimedOut(elapsedMs);
+    const success = !timedOut && isCorrectAnswer(question, userResponseId);
     const hpLoss = success ? 0 : brainrunHpLossForDifficulty(question.difficulty);
+    const bossDamage = isBossRoom ? brainrunBossDamage(elapsedMs, success) : 0;
     const newResponses: BrainrunRoomResponse[] = [
       ...responses,
-      { questionId, responseId: userResponseId, success, hpLoss },
+      {
+        questionId,
+        responseId: userResponseId,
+        success,
+        hpLoss,
+        ...(isBossRoom ? { bossDamage, timedOut } : {}),
+      },
     ];
     const newHealthPoint = run.healthPoint - hpLoss;
     const died = newHealthPoint <= 0;
+    const newBossHealthPoint = isBossRoom
+      ? Math.max((activeRoom.bossHealthPoint ?? BRAINRUN_BOSS_MAX_HP) - bossDamage, 0)
+      : null;
+    const bossDefeated = isBossRoom && newBossHealthPoint === 0;
     // La salle se termine dès que toutes ses questions ont été posées, qu'elles aient
     // été réussies ou non — seule la mort met fin à la salle avant la dernière question.
-    const roomQuestionsDone = newResponses.length === activeRoom.questionIds.length;
+    // Un combat de boss n'a pas de fin sur épuisement des questions : il ne se termine
+    // que lorsque le boss est vaincu (bossDefeated) ou que le joueur meurt.
+    const roomQuestionsDone = !isBossRoom && newResponses.length === activeRoom.questionIds.length;
 
     await prisma.brainrunRun.update({
       where: { id: run.id },
@@ -185,14 +223,23 @@ export class BrainrunService {
     if (died) {
       await prisma.brainrunRoom.update({
         where: { id: activeRoom.id },
-        data: { responses: newResponses, status: "FAILED" },
+        data: {
+          responses: newResponses,
+          status: "FAILED",
+          ...(isBossRoom ? { bossHealthPoint: newBossHealthPoint } : {}),
+        },
       });
       await this.finalizeRun(run.id, "LOST");
-    } else if (roomQuestionsDone) {
+    } else if (bossDefeated || roomQuestionsDone) {
       const goldEarned = BRAINRUN_GOLD_BY_ROOM_TYPE[activeRoom.type as CombatRoomType];
       await prisma.brainrunRoom.update({
         where: { id: activeRoom.id },
-        data: { responses: newResponses, status: "CLEARED", goldEarned },
+        data: {
+          responses: newResponses,
+          status: "CLEARED",
+          goldEarned,
+          ...(isBossRoom ? { bossHealthPoint: newBossHealthPoint } : {}),
+        },
       });
       await prisma.brainrunRun.update({
         where: { id: run.id },
@@ -201,9 +248,34 @@ export class BrainrunService {
       // L'avancée vers la salle suivante est différée : acknowledgeRoom() la déclenche
       // une fois que le joueur a vu le récap (or gagné / PV perdus) de cette salle.
     } else {
+      // Boss non vaincu : si la réserve de questions déjà tirées est épuisée, on en tire
+      // une nouvelle à la volée (pas de limite de questions pour un combat de boss).
+      let updatedQuestionIds = activeRoom.questionIds;
+      let updatedUsedQuestionIds: number[] | undefined;
+      if (isBossRoom && newResponses.length === activeRoom.questionIds.length) {
+        updatedUsedQuestionIds = [...run.usedQuestionIds, ...activeRoom.questionIds];
+        const nextQuestionId = await this.getNextBossQuestionId(
+          run.currentAct,
+          updatedUsedQuestionIds,
+          userId,
+        );
+        updatedQuestionIds = [...activeRoom.questionIds, nextQuestionId];
+        await prisma.brainrunRun.update({
+          where: { id: run.id },
+          data: { usedQuestionIds: updatedUsedQuestionIds },
+        });
+      }
+
       await prisma.brainrunRoom.update({
         where: { id: activeRoom.id },
-        data: { responses: newResponses },
+        data: {
+          responses: newResponses,
+          questionIds: updatedQuestionIds,
+          // Le chrono de la question suivante ne démarre qu'à l'appel explicite de
+          // prepareNextBossQuestion(), une fois que le joueur a fini de lire le feedback
+          // de cette réponse — sinon le temps de lecture serait décompté à son insu.
+          ...(isBossRoom ? { bossHealthPoint: newBossHealthPoint, questionStartedAt: null } : {}),
+        },
       });
     }
 
@@ -223,6 +295,32 @@ export class BrainrunService {
     }
 
     await this.advanceAfterRoomClear(run.id, run.currentAct, run.currentSequence);
+    return this.getStateById(run.id);
+  }
+
+  /**
+   * Démarre le chrono de la prochaine question d'un combat de boss, une fois que le joueur
+   * a terminé de lire le feedback de la question précédente (cf. commentaire dans submitAnswer :
+   * le chrono ne doit pas courir pendant que le joueur lit ce feedback).
+   */
+  async prepareNextBossQuestion(runId: string, userId: string): Promise<BrainrunStateDTO> {
+    const run = await this.getOwnedInProgressRun(runId, userId);
+    const activeRoom = this.findActiveRoom(run);
+
+    if (activeRoom.type !== "BOSS" || activeRoom.status !== "ACTIVE") {
+      throw createError({
+        statusCode: 409,
+        statusMessage: "Aucun combat de boss en attente de question.",
+      });
+    }
+
+    if (activeRoom.questionStartedAt === null) {
+      await prisma.brainrunRoom.update({
+        where: { id: activeRoom.id },
+        data: { questionStartedAt: new Date() },
+      });
+    }
+
     return this.getStateById(run.id);
   }
 
@@ -307,6 +405,40 @@ export class BrainrunService {
     }
   }
 
+  /**
+   * Tire la prochaine question d'un combat de boss en cours, en excluant les questions déjà
+   * posées dans la run. Si le palier de difficulté n'a plus de question inédite disponible
+   * (run très longue), on retombe sur n'importe quelle question de ce palier plutôt que
+   * d'échouer — le combat de boss ne doit jamais se retrouver bloqué faute de question.
+   */
+  private async getNextBossQuestionId(
+    act: number,
+    excludeIds: number[],
+    userId: string,
+  ): Promise<number> {
+    const [minDifficulty, maxDifficulty] = BRAINRUN_DIFFICULTY_BY_ACT[act]!.BOSS;
+    const [id] = await questionService.getRandomIdsByDifficulty(
+      minDifficulty,
+      maxDifficulty,
+      1,
+      excludeIds,
+      userId,
+    );
+    if (id !== undefined) return id;
+
+    const [fallbackId] = await questionService.getRandomIdsByDifficulty(
+      minDifficulty,
+      maxDifficulty,
+      1,
+      [],
+      userId,
+    );
+    if (fallbackId === undefined) {
+      throw createError({ statusCode: 500, statusMessage: "Aucune question de boss disponible." });
+    }
+    return fallbackId;
+  }
+
   private async getOwnedInProgressRun(runId: string, userId: string) {
     const run = await prisma.brainrunRun.findFirst({
       where: { id: runId, userId },
@@ -380,6 +512,11 @@ export class BrainrunService {
   }
 
   private toRoomDTO(room: BrainrunRoomRow): BrainrunRoomDTO {
+    const questionDeadline =
+      room.type === "BOSS" && room.status === "ACTIVE" && room.questionStartedAt
+        ? new Date(room.questionStartedAt.getTime() + BRAINRUN_BOSS_QUESTION_TIME_MS)
+        : null;
+
     return {
       id: room.id,
       runId: room.runId,
@@ -391,6 +528,9 @@ export class BrainrunService {
       questionIds: room.questionIds,
       responses: (room.responses as unknown as BrainrunRoomResponse[]) ?? [],
       goldEarned: room.goldEarned,
+      bossHealthPoint: room.bossHealthPoint,
+      bossMaxHealthPoint: room.bossMaxHealthPoint,
+      questionDeadline,
     };
   }
 }

--- a/server/services/BrainrunService.ts
+++ b/server/services/BrainrunService.ts
@@ -1,0 +1,401 @@
+import prisma from "~~/server/utils/prisma";
+import { isCorrectAnswer, questionService } from "~~/server/services/QuestionService";
+import { updateUserProgress } from "~~/server/utils/userProgressHelper";
+import { checkAndAwardAchievements } from "~~/server/utils/achievementHelper";
+import {
+  brainrunHpLossForDifficulty,
+  calculBrainrunUserXP,
+  generateActChoicePoints,
+  instantRoomHealthDelta,
+  nextRoomAfterClear,
+} from "~~/server/utils/brainrunLogic";
+import {
+  BRAINRUN_DIFFICULTY_BY_ACT,
+  BRAINRUN_GOLD_BY_ROOM_TYPE,
+  BRAINRUN_MAX_HP,
+  BRAINRUN_QUESTIONS_PER_ROOM,
+  BRAINRUN_ROOMS_PER_ACT,
+  BRAINRUN_START_HP,
+} from "~~/server/utils/brainrunConfig";
+import { QuestionDataDTO } from "#shared/question";
+import type {
+  BrainrunRoomDTO,
+  BrainrunRoomResponse,
+  BrainrunRoomType,
+  BrainrunRunDTO,
+  BrainrunStateDTO,
+} from "#shared/brainrun";
+
+type CombatRoomType = "STANDARD" | "ELITE" | "BOSS";
+
+export class BrainrunService {
+  /**
+   * Reprend la run en cours si elle existe, ou renvoie l'état de la dernière run terminée
+   * (pour que l'écran de fin s'affiche) sans en recréer une automatiquement. Seule
+   * startNewRun() démarre explicitement une nouvelle run.
+   */
+  async getOrStartRun(userId: string): Promise<BrainrunStateDTO> {
+    const lastRun = await prisma.brainrunRun.findFirst({
+      where: { userId },
+      orderBy: { createDate: "desc" },
+      include: { rooms: true },
+    });
+
+    if (!lastRun) {
+      return this.createRun(userId);
+    }
+
+    return this.buildState(lastRun);
+  }
+
+  async startNewRun(userId: string): Promise<BrainrunStateDTO> {
+    await this.abandonRun(userId);
+    return this.createRun(userId);
+  }
+
+  private async createRun(userId: string): Promise<BrainrunStateDTO> {
+    const created = await prisma.brainrunRun.create({
+      data: {
+        userId,
+        healthPoint: BRAINRUN_START_HP,
+        maxHealthPoint: BRAINRUN_MAX_HP,
+      },
+    });
+    await this.seedAct(created.id, 1);
+    return this.getStateById(created.id);
+  }
+
+  async abandonRun(userId: string): Promise<void> {
+    const run = await prisma.brainrunRun.findFirst({ where: { userId, status: "IN_PROGRESS" } });
+    if (!run) return;
+    await prisma.brainrunRun.update({
+      where: { id: run.id },
+      data: { status: "ABANDONED", endDate: new Date() },
+    });
+    const totalGames = await prisma.brainrunRun.count({
+      where: { userId, status: { in: ["WON", "LOST", "ABANDONED"] } },
+    });
+    await checkAndAwardAchievements(userId, "brainrunGames", totalGames);
+  }
+
+  async chooseOption(
+    runId: string,
+    choice: BrainrunRoomType,
+    userId: string,
+  ): Promise<BrainrunStateDTO> {
+    const run = await this.getOwnedInProgressRun(runId, userId);
+    const activeRoom = this.findActiveRoom(run);
+
+    if (activeRoom.type !== null) {
+      throw createError({ statusCode: 409, statusMessage: "Cette salle n'attend pas de choix." });
+    }
+    if (!activeRoom.choiceTypes.includes(choice)) {
+      throw createError({ statusCode: 400, statusMessage: "Choix non proposé pour cette salle." });
+    }
+
+    if (choice === "REST") {
+      // Salle "cleared" mais l'avancée reste différée jusqu'à acknowledgeRoom(), pour laisser
+      // le temps au joueur de voir le récap (+1 PV) avant de passer à la suite.
+      const newHealthPoint = Math.min(
+        run.maxHealthPoint,
+        run.healthPoint + instantRoomHealthDelta("REST"),
+      );
+      await prisma.brainrunRoom.update({
+        where: { id: activeRoom.id },
+        data: { type: choice, status: "CLEARED", goldEarned: 0 },
+      });
+      await prisma.brainrunRun.update({
+        where: { id: run.id },
+        data: { healthPoint: newHealthPoint },
+      });
+    } else if (choice === "SHOP" || choice === "EVENT") {
+      // Aucun effet de jeu ; l'écran "en construction" côté client fait déjà office
+      // de confirmation avant l'appel, donc on avance directement.
+      await prisma.brainrunRoom.update({
+        where: { id: activeRoom.id },
+        data: { type: choice, status: "CLEARED", goldEarned: 0 },
+      });
+      await this.advanceAfterRoomClear(run.id, run.currentAct, run.currentSequence);
+    } else {
+      const combatType = choice as CombatRoomType;
+      const [minDifficulty, maxDifficulty] =
+        BRAINRUN_DIFFICULTY_BY_ACT[run.currentAct]![combatType]!;
+      const count = BRAINRUN_QUESTIONS_PER_ROOM[combatType];
+      const questionIds = await questionService.getRandomIdsByDifficulty(
+        minDifficulty,
+        maxDifficulty,
+        count,
+        run.usedQuestionIds,
+        userId,
+      );
+
+      await prisma.brainrunRoom.update({
+        where: { id: activeRoom.id },
+        data: { type: choice, status: "ACTIVE", questionIds, responses: [] },
+      });
+      await prisma.brainrunRun.update({
+        where: { id: run.id },
+        data: { usedQuestionIds: [...run.usedQuestionIds, ...questionIds] },
+      });
+    }
+
+    return this.getStateById(run.id);
+  }
+
+  async submitAnswer(
+    runId: string,
+    questionId: number,
+    userResponseId: number,
+    userId: string,
+  ): Promise<BrainrunStateDTO> {
+    const run = await this.getOwnedInProgressRun(runId, userId);
+    const activeRoom = this.findActiveRoom(run);
+
+    if (activeRoom.type === null || activeRoom.status !== "ACTIVE") {
+      throw createError({
+        statusCode: 409,
+        statusMessage: "Aucune question en attente pour cette salle.",
+      });
+    }
+
+    const responses = (activeRoom.responses as unknown as BrainrunRoomResponse[]) ?? [];
+    const expectedQuestionId = activeRoom.questionIds[responses.length];
+    if (expectedQuestionId !== questionId) {
+      throw createError({ statusCode: 400, statusMessage: "Cette question n'est pas attendue." });
+    }
+
+    const question = await prisma.question.findFirstOrThrow({ where: { id: questionId } });
+    const success = isCorrectAnswer(question, userResponseId);
+    const hpLoss = success ? 0 : brainrunHpLossForDifficulty(question.difficulty);
+    const newResponses: BrainrunRoomResponse[] = [
+      ...responses,
+      { questionId, responseId: userResponseId, success, hpLoss },
+    ];
+    const newHealthPoint = run.healthPoint - hpLoss;
+    const died = newHealthPoint <= 0;
+    // La salle se termine dès que toutes ses questions ont été posées, qu'elles aient
+    // été réussies ou non — seule la mort met fin à la salle avant la dernière question.
+    const roomQuestionsDone = newResponses.length === activeRoom.questionIds.length;
+
+    await prisma.brainrunRun.update({
+      where: { id: run.id },
+      data: { healthPoint: Math.max(newHealthPoint, 0) },
+    });
+
+    if (died) {
+      await prisma.brainrunRoom.update({
+        where: { id: activeRoom.id },
+        data: { responses: newResponses, status: "FAILED" },
+      });
+      await this.finalizeRun(run.id, "LOST");
+    } else if (roomQuestionsDone) {
+      const goldEarned = BRAINRUN_GOLD_BY_ROOM_TYPE[activeRoom.type as CombatRoomType];
+      await prisma.brainrunRoom.update({
+        where: { id: activeRoom.id },
+        data: { responses: newResponses, status: "CLEARED", goldEarned },
+      });
+      await prisma.brainrunRun.update({
+        where: { id: run.id },
+        data: { gold: { increment: goldEarned } },
+      });
+      // L'avancée vers la salle suivante est différée : acknowledgeRoom() la déclenche
+      // une fois que le joueur a vu le récap (or gagné / PV perdus) de cette salle.
+    } else {
+      await prisma.brainrunRoom.update({
+        where: { id: activeRoom.id },
+        data: { responses: newResponses },
+      });
+    }
+
+    return this.getStateById(run.id);
+  }
+
+  /**
+   * Confirme le récap de fin de salle (CLEARED) et fait avancer la run vers la salle
+   * suivante (ou déclenche la fin de run si c'était le boss du dernier acte).
+   */
+  async acknowledgeRoom(runId: string, userId: string): Promise<BrainrunStateDTO> {
+    const run = await this.getOwnedInProgressRun(runId, userId);
+    const activeRoom = this.findActiveRoom(run);
+
+    if (activeRoom.status !== "CLEARED") {
+      throw createError({ statusCode: 409, statusMessage: "Aucune salle terminée à valider." });
+    }
+
+    await this.advanceAfterRoomClear(run.id, run.currentAct, run.currentSequence);
+    return this.getStateById(run.id);
+  }
+
+  private async getStateById(runId: string): Promise<BrainrunStateDTO> {
+    const run = await prisma.brainrunRun.findUniqueOrThrow({
+      where: { id: runId },
+      include: { rooms: true },
+    });
+    return this.buildState(run);
+  }
+
+  private async seedAct(runId: string, act: number): Promise<void> {
+    const choicePoints = generateActChoicePoints();
+    await prisma.brainrunRoom.createMany({
+      data: choicePoints.map((point) => ({
+        runId,
+        act,
+        sequence: point.sequence,
+        choiceTypes: point.choiceTypes,
+      })),
+    });
+    await prisma.brainrunRoom.create({
+      data: {
+        runId,
+        act,
+        sequence: BRAINRUN_ROOMS_PER_ACT,
+        choiceTypes: ["BOSS"],
+      },
+    });
+  }
+
+  private async advanceAfterRoomClear(runId: string, act: number, sequence: number): Promise<void> {
+    const outcome = nextRoomAfterClear(act, sequence);
+
+    if (outcome.kind === "RUN_WON") {
+      await this.finalizeRun(runId, "WON");
+      return;
+    }
+
+    if (outcome.act !== act) {
+      const nextActSeeded = await prisma.brainrunRoom.findFirst({
+        where: { runId, act: outcome.act },
+      });
+      if (!nextActSeeded) {
+        await this.seedAct(runId, outcome.act);
+      }
+    }
+
+    await prisma.brainrunRun.update({
+      where: { id: runId },
+      data: { currentAct: outcome.act, currentSequence: outcome.sequence },
+    });
+  }
+
+  private async finalizeRun(runId: string, status: "WON" | "LOST"): Promise<void> {
+    const run = await prisma.brainrunRun.findUniqueOrThrow({
+      where: { id: runId },
+      include: { rooms: true },
+    });
+
+    const clearedRooms = run.rooms
+      .filter((r) => r.status === "CLEARED" && r.type !== null)
+      .map((r) => ({ type: r.type as BrainrunRoomType }));
+    const xpEarned = calculBrainrunUserXP(clearedRooms, status === "WON");
+
+    await prisma.brainrunRun.update({
+      where: { id: runId },
+      data: { status, endDate: new Date(), xpEarned },
+    });
+    await updateUserProgress(run.userId, xpEarned);
+
+    const totalGames = await prisma.brainrunRun.count({
+      where: { userId: run.userId, status: { in: ["WON", "LOST", "ABANDONED"] } },
+    });
+    await checkAndAwardAchievements(run.userId, "brainrunGames", totalGames);
+
+    if (status === "WON") {
+      const totalWins = await prisma.brainrunRun.count({
+        where: { userId: run.userId, status: "WON" },
+      });
+      await checkAndAwardAchievements(run.userId, "brainrunWins", totalWins);
+    }
+  }
+
+  private async getOwnedInProgressRun(runId: string, userId: string) {
+    const run = await prisma.brainrunRun.findFirst({
+      where: { id: runId, userId },
+      include: { rooms: true },
+    });
+    if (!run) {
+      throw createError({ statusCode: 404, statusMessage: "Run introuvable." });
+    }
+    if (run.status !== "IN_PROGRESS") {
+      throw createError({ statusCode: 409, statusMessage: "Cette run est déjà terminée." });
+    }
+    return run;
+  }
+
+  private findActiveRoom<T extends { act: number; sequence: number }>(run: {
+    currentAct: number;
+    currentSequence: number;
+    rooms: T[];
+  }): T {
+    const room = run.rooms.find(
+      (r) => r.act === run.currentAct && r.sequence === run.currentSequence,
+    );
+    if (!room) {
+      throw createError({ statusCode: 500, statusMessage: "Salle active introuvable." });
+    }
+    return room;
+  }
+
+  private async buildState(
+    run: BrainrunRunRow & { rooms: BrainrunRoomRow[] },
+  ): Promise<BrainrunStateDTO> {
+    const activeRoom = this.findActiveRoom(run);
+    const awaitingChoice = activeRoom.type === null;
+
+    let currentQuestion = null;
+    if (!awaitingChoice && activeRoom.status === "ACTIVE") {
+      const responses = (activeRoom.responses as unknown as BrainrunRoomResponse[]) ?? [];
+      const nextQuestionId = activeRoom.questionIds[responses.length];
+      if (nextQuestionId !== undefined) {
+        const question = await questionService.getById(nextQuestionId);
+        if (question) {
+          const questionData = question.data as unknown as QuestionDataDTO;
+          questionData.propositions = questionService.shuffleArray(questionData.propositions);
+          currentQuestion = { ...question, data: questionData } as any;
+        }
+      }
+    }
+
+    return {
+      run: this.toRunDTO(run),
+      currentRoom: this.toRoomDTO(activeRoom),
+      currentQuestion,
+      awaitingChoice,
+    };
+  }
+
+  private toRunDTO(run: BrainrunRunRow): BrainrunRunDTO {
+    return {
+      id: run.id,
+      userId: run.userId,
+      status: run.status as BrainrunRunDTO["status"],
+      currentAct: run.currentAct,
+      currentSequence: run.currentSequence,
+      healthPoint: run.healthPoint,
+      maxHealthPoint: run.maxHealthPoint,
+      gold: run.gold,
+      xpEarned: run.xpEarned,
+      createDate: run.createDate,
+      endDate: run.endDate,
+    };
+  }
+
+  private toRoomDTO(room: BrainrunRoomRow): BrainrunRoomDTO {
+    return {
+      id: room.id,
+      runId: room.runId,
+      act: room.act,
+      sequence: room.sequence,
+      type: room.type as BrainrunRoomType | null,
+      status: room.status as BrainrunRoomDTO["status"],
+      choiceTypes: room.choiceTypes as BrainrunRoomType[],
+      questionIds: room.questionIds,
+      responses: (room.responses as unknown as BrainrunRoomResponse[]) ?? [],
+      goldEarned: room.goldEarned,
+    };
+  }
+}
+
+type BrainrunRunRow = Awaited<ReturnType<typeof prisma.brainrunRun.findUniqueOrThrow>>;
+type BrainrunRoomRow = Awaited<ReturnType<typeof prisma.brainrunRoom.findFirstOrThrow>>;
+
+export const brainrunService = new BrainrunService();

--- a/server/services/QuestionService.ts
+++ b/server/services/QuestionService.ts
@@ -3,6 +3,11 @@ import prisma from "~~/server/utils/prisma";
 import { QuestionDataDTO, QuestionDTO, QuestionReportingDTO } from "#shared/question";
 import type { ReportingDTO } from "#shared/DTO/reportingDTO";
 
+/** Vrai si la réponse donnée correspond à la réponse attendue de la question. Source unique de vérité, réutilisée par ResponseService et BrainrunService. */
+export function isCorrectAnswer(question: { data: unknown }, userResponseId: number): boolean {
+  return (question.data as unknown as QuestionDataDTO).response === userResponseId;
+}
+
 export class QuestionService {
   async getById(id: number) {
     const question = await prisma.question.findFirst({ where: { id } });
@@ -74,6 +79,40 @@ export class QuestionService {
       ...question,
       themes: themes.map((t) => t.name),
     };
+  }
+
+  /**
+   * Jusqu'à `count` IDs de questions aléatoires dans [minDifficulty, maxDifficulty], en excluant
+   * `excludeIds` (anti-répétition sur une run Brainrun). Préfère les questions jamais réussies par
+   * l'utilisateur (même logique que getRandom) ; si le pool est trop restreint, retombe sur toutes
+   * les questions de la plage sans cette préférence plutôt que de renvoyer moins que `count`.
+   */
+  async getRandomIdsByDifficulty(
+    minDifficulty: number,
+    maxDifficulty: number,
+    count: number,
+    excludeIds: number[],
+    userId?: string,
+  ): Promise<number[]> {
+    const baseWhere = {
+      deleted: false,
+      difficulty: { gte: minDifficulty, lte: maxDifficulty },
+      id: { notIn: excludeIds },
+    };
+
+    let candidates = await prisma.question.findMany({
+      where: {
+        ...baseWhere,
+        ...(userId && { Response: { none: { userId, success: true } } }),
+      },
+      select: { id: true },
+    });
+
+    if (candidates.length < count) {
+      candidates = await prisma.question.findMany({ where: baseWhere, select: { id: true } });
+    }
+
+    return this.shuffleArray(candidates.map((c) => c.id)).slice(0, count);
   }
 
   async create(question: QuestionDTO, authorName: string) {
@@ -273,7 +312,7 @@ export class QuestionService {
     return ids[randomIndex]?.id;
   }
 
-  private shuffleArray<T>(array: T[]): T[] {
+  shuffleArray<T>(array: T[]): T[] {
     for (let i = array.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [array[i], array[j]] = [array[j]!, array[i]!]; // Échange des éléments

--- a/server/services/ResponseService.ts
+++ b/server/services/ResponseService.ts
@@ -1,6 +1,6 @@
 import prisma from "~~/server/utils/prisma";
 import type { ResponseDTO } from "#shared/DTO/responseDTO";
-import { QuestionDataDTO } from "#shared/question";
+import { isCorrectAnswer } from "~~/server/services/QuestionService";
 
 export class ResponseService {
   async validateResponse(body: ResponseDTO, userId: string) {
@@ -10,7 +10,7 @@ export class ResponseService {
 
     if (!question?.data) return;
 
-    const success = (question.data as unknown as QuestionDataDTO).response == body.userResponseId;
+    const success = isCorrectAnswer(question, body.userResponseId);
 
     await prisma.questionResponse.create({
       data: {

--- a/server/utils/achievementHelper.ts
+++ b/server/utils/achievementHelper.ts
@@ -18,7 +18,9 @@ type ActionType =
   | "brGames"
   | "brWins"
   | "showdownGames"
-  | "showdownWins";
+  | "showdownWins"
+  | "brainrunGames"
+  | "brainrunWins";
 
 // Conditions d'achievement
 interface AchievementCondition {

--- a/server/utils/brainrunConfig.ts
+++ b/server/utils/brainrunConfig.ts
@@ -1,11 +1,23 @@
 import type { BrainrunRoomType } from "#shared/brainrun";
 import {
+  BRAINRUN_BOSS_BASE_DAMAGE,
+  BRAINRUN_BOSS_FAST_ANSWER_MS,
+  BRAINRUN_BOSS_FAST_DAMAGE_MULTIPLIER,
+  BRAINRUN_BOSS_QUESTION_TIME_MS,
   BRAINRUN_CHOICE_POINTS_PER_ACT,
   BRAINRUN_ROOMS_PER_ACT,
   BRAINRUN_TOTAL_ACTS,
 } from "#shared/brainrun";
 
-export { BRAINRUN_CHOICE_POINTS_PER_ACT, BRAINRUN_ROOMS_PER_ACT, BRAINRUN_TOTAL_ACTS };
+export {
+  BRAINRUN_BOSS_BASE_DAMAGE,
+  BRAINRUN_BOSS_FAST_ANSWER_MS,
+  BRAINRUN_BOSS_FAST_DAMAGE_MULTIPLIER,
+  BRAINRUN_BOSS_QUESTION_TIME_MS,
+  BRAINRUN_CHOICE_POINTS_PER_ACT,
+  BRAINRUN_ROOMS_PER_ACT,
+  BRAINRUN_TOTAL_ACTS,
+};
 
 export const BRAINRUN_START_HP = 3;
 export const BRAINRUN_MAX_HP = 3;
@@ -24,10 +36,11 @@ export const BRAINRUN_XP_BY_ROOM_TYPE: Record<"STANDARD" | "ELITE" | "BOSS", num
 };
 export const BRAINRUN_WIN_BONUS_XP = 150;
 
-export const BRAINRUN_QUESTIONS_PER_ROOM: Record<"STANDARD" | "ELITE" | "BOSS", number> = {
+/** Nombre de questions pour les salles de combat standard ; le combat de boss n'a pas de
+ * limite de questions, il continue jusqu'à ce que le boss soit à 0 PV (cf. BRAINRUN_BOSS_MAX_HP). */
+export const BRAINRUN_QUESTIONS_PER_ROOM: Record<"STANDARD" | "ELITE", number> = {
   STANDARD: 4,
   ELITE: 5,
-  BOSS: 5,
 };
 
 /** Plage de difficulté (inclusive, échelle Question.difficulty 1-5) par acte et type de salle de combat. */
@@ -50,3 +63,8 @@ export const BRAINRUN_MIN_EVENT_OFFERS = 2;
 export const BRAINRUN_INSTANT_ROOM_TYPES: BrainrunRoomType[] = ["REST", "SHOP", "EVENT"];
 /** Types de salle "de combat", avec des questions, de l'or et de l'XP. */
 export const BRAINRUN_COMBAT_ROOM_TYPES: BrainrunRoomType[] = ["STANDARD", "ELITE", "BOSS"];
+
+/** Nombre de coups à dégâts de base pour vaincre le boss (calibrage des PV) ; le combat n'est
+ * jamais limité en nombre de questions, ce chiffre est indicatif du rythme attendu. */
+const BRAINRUN_BOSS_BASE_HIT_COUNT = 5;
+export const BRAINRUN_BOSS_MAX_HP = BRAINRUN_BOSS_BASE_HIT_COUNT * BRAINRUN_BOSS_BASE_DAMAGE;

--- a/server/utils/brainrunConfig.ts
+++ b/server/utils/brainrunConfig.ts
@@ -1,0 +1,52 @@
+import type { BrainrunRoomType } from "#shared/brainrun";
+import {
+  BRAINRUN_CHOICE_POINTS_PER_ACT,
+  BRAINRUN_ROOMS_PER_ACT,
+  BRAINRUN_TOTAL_ACTS,
+} from "#shared/brainrun";
+
+export { BRAINRUN_CHOICE_POINTS_PER_ACT, BRAINRUN_ROOMS_PER_ACT, BRAINRUN_TOTAL_ACTS };
+
+export const BRAINRUN_START_HP = 3;
+export const BRAINRUN_MAX_HP = 3;
+
+export const BRAINRUN_GOLD_BY_ROOM_TYPE: Record<"STANDARD" | "ELITE" | "BOSS", number> = {
+  STANDARD: 10,
+  ELITE: 25,
+  BOSS: 50,
+};
+
+/** XP par salle de combat nettoyée ; REST/SHOP/EVENT ne rapportent pas d'XP. Valeurs indicatives, à ajuster après tests. */
+export const BRAINRUN_XP_BY_ROOM_TYPE: Record<"STANDARD" | "ELITE" | "BOSS", number> = {
+  STANDARD: 15,
+  ELITE: 35,
+  BOSS: 70,
+};
+export const BRAINRUN_WIN_BONUS_XP = 150;
+
+export const BRAINRUN_QUESTIONS_PER_ROOM: Record<"STANDARD" | "ELITE" | "BOSS", number> = {
+  STANDARD: 4,
+  ELITE: 5,
+  BOSS: 5,
+};
+
+/** Plage de difficulté (inclusive, échelle Question.difficulty 1-5) par acte et type de salle de combat. */
+export const BRAINRUN_DIFFICULTY_BY_ACT: Record<
+  number,
+  Record<"STANDARD" | "ELITE" | "BOSS", [number, number]>
+> = {
+  1: { STANDARD: [1, 1], ELITE: [2, 2], BOSS: [2, 2] },
+  2: { STANDARD: [2, 3], ELITE: [3, 3], BOSS: [3, 3] },
+  3: { STANDARD: [3, 4], ELITE: [4, 4], BOSS: [5, 5] },
+};
+
+/** Quotas minimums que l'algorithme de génération des points de choix d'un acte doit respecter. */
+export const BRAINRUN_MIN_PURE_COMBAT_RATIO = 0.5; // au moins 50% des points = uniquement [STANDARD, ELITE]
+export const BRAINRUN_MIN_SHOP_OFFERS = 1;
+export const BRAINRUN_MIN_REST_OFFERS = 1;
+export const BRAINRUN_MIN_EVENT_OFFERS = 2;
+
+/** Types de salle qui, une fois choisis, se résolvent instantanément (pas de question). */
+export const BRAINRUN_INSTANT_ROOM_TYPES: BrainrunRoomType[] = ["REST", "SHOP", "EVENT"];
+/** Types de salle "de combat", avec des questions, de l'or et de l'XP. */
+export const BRAINRUN_COMBAT_ROOM_TYPES: BrainrunRoomType[] = ["STANDARD", "ELITE", "BOSS"];

--- a/server/utils/brainrunLogic.test.ts
+++ b/server/utils/brainrunLogic.test.ts
@@ -1,14 +1,22 @@
 import { describe, it, expect } from "vite-plus/test";
 import {
+  brainrunBossDamage,
   brainrunHpLossForDifficulty,
   calculBrainrunUserXP,
   generateActChoicePoints,
   instantRoomHealthDelta,
   isAwaitingChoice,
+  isBossAnswerTimedOut,
   nextRoomAfterClear,
   shouldEndRunOnDamage,
 } from "./brainrunLogic";
-import { BRAINRUN_CHOICE_POINTS_PER_ACT } from "./brainrunConfig";
+import {
+  BRAINRUN_BOSS_BASE_DAMAGE,
+  BRAINRUN_BOSS_FAST_ANSWER_MS,
+  BRAINRUN_BOSS_FAST_DAMAGE_MULTIPLIER,
+  BRAINRUN_BOSS_QUESTION_TIME_MS,
+  BRAINRUN_CHOICE_POINTS_PER_ACT,
+} from "./brainrunConfig";
 
 describe("brainrunHpLossForDifficulty", () => {
   it("maps difficulty tiers to the expected HP loss", () => {
@@ -40,6 +48,36 @@ describe("instantRoomHealthDelta", () => {
     expect(instantRoomHealthDelta("REST")).toBe(1);
     expect(instantRoomHealthDelta("SHOP")).toBe(0);
     expect(instantRoomHealthDelta("EVENT")).toBe(0);
+  });
+});
+
+describe("isBossAnswerTimedOut", () => {
+  it("is true once the elapsed time reaches the boss question time limit", () => {
+    expect(isBossAnswerTimedOut(0)).toBe(false);
+    expect(isBossAnswerTimedOut(BRAINRUN_BOSS_QUESTION_TIME_MS - 1)).toBe(false);
+    expect(isBossAnswerTimedOut(BRAINRUN_BOSS_QUESTION_TIME_MS)).toBe(true);
+    expect(isBossAnswerTimedOut(BRAINRUN_BOSS_QUESTION_TIME_MS + 1000)).toBe(true);
+  });
+});
+
+describe("brainrunBossDamage", () => {
+  it("deals no damage on an incorrect answer, regardless of elapsed time", () => {
+    expect(brainrunBossDamage(0, false)).toBe(0);
+    expect(brainrunBossDamage(BRAINRUN_BOSS_FAST_ANSWER_MS - 1, false)).toBe(0);
+  });
+
+  it("deals no damage once the question has timed out, even if marked correct", () => {
+    expect(brainrunBossDamage(BRAINRUN_BOSS_QUESTION_TIME_MS, true)).toBe(0);
+  });
+
+  it("deals base damage on a correct answer at normal speed", () => {
+    expect(brainrunBossDamage(BRAINRUN_BOSS_FAST_ANSWER_MS, true)).toBe(BRAINRUN_BOSS_BASE_DAMAGE);
+  });
+
+  it("deals multiplied damage on a fast correct answer", () => {
+    expect(brainrunBossDamage(BRAINRUN_BOSS_FAST_ANSWER_MS - 1, true)).toBe(
+      BRAINRUN_BOSS_BASE_DAMAGE * BRAINRUN_BOSS_FAST_DAMAGE_MULTIPLIER,
+    );
   });
 });
 

--- a/server/utils/brainrunLogic.test.ts
+++ b/server/utils/brainrunLogic.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vite-plus/test";
+import {
+  brainrunHpLossForDifficulty,
+  calculBrainrunUserXP,
+  generateActChoicePoints,
+  instantRoomHealthDelta,
+  isAwaitingChoice,
+  nextRoomAfterClear,
+  shouldEndRunOnDamage,
+} from "./brainrunLogic";
+import { BRAINRUN_CHOICE_POINTS_PER_ACT } from "./brainrunConfig";
+
+describe("brainrunHpLossForDifficulty", () => {
+  it("maps difficulty tiers to the expected HP loss", () => {
+    expect(brainrunHpLossForDifficulty(1)).toBe(1);
+    expect(brainrunHpLossForDifficulty(2)).toBe(1);
+    expect(brainrunHpLossForDifficulty(3)).toBe(2);
+    expect(brainrunHpLossForDifficulty(4)).toBe(2);
+    expect(brainrunHpLossForDifficulty(5)).toBe(3);
+  });
+});
+
+describe("shouldEndRunOnDamage", () => {
+  it("ends the run at 0 HP or below, not above", () => {
+    expect(shouldEndRunOnDamage(0)).toBe(true);
+    expect(shouldEndRunOnDamage(-1)).toBe(true);
+    expect(shouldEndRunOnDamage(1)).toBe(false);
+  });
+});
+
+describe("isAwaitingChoice", () => {
+  it("is true only when the room type hasn't been picked yet", () => {
+    expect(isAwaitingChoice({ type: null })).toBe(true);
+    expect(isAwaitingChoice({ type: "STANDARD" })).toBe(false);
+  });
+});
+
+describe("instantRoomHealthDelta", () => {
+  it("only REST heals", () => {
+    expect(instantRoomHealthDelta("REST")).toBe(1);
+    expect(instantRoomHealthDelta("SHOP")).toBe(0);
+    expect(instantRoomHealthDelta("EVENT")).toBe(0);
+  });
+});
+
+describe("nextRoomAfterClear", () => {
+  it("moves to the next sequence within the same act", () => {
+    expect(nextRoomAfterClear(1, 1)).toEqual({ kind: "AWAIT_CHOICE", act: 1, sequence: 2 });
+    expect(nextRoomAfterClear(2, 6)).toEqual({ kind: "AWAIT_CHOICE", act: 2, sequence: 7 });
+  });
+
+  it("moves to the next act after the boss room, unless it was the last act", () => {
+    expect(nextRoomAfterClear(1, 7)).toEqual({ kind: "AWAIT_CHOICE", act: 2, sequence: 1 });
+    expect(nextRoomAfterClear(2, 7)).toEqual({ kind: "AWAIT_CHOICE", act: 3, sequence: 1 });
+  });
+
+  it("declares the run won after act 3's boss room", () => {
+    expect(nextRoomAfterClear(3, 7)).toEqual({ kind: "RUN_WON" });
+  });
+});
+
+describe("calculBrainrunUserXP", () => {
+  it("sums XP per combat room type and adds nothing for a lost run", () => {
+    const xp = calculBrainrunUserXP(
+      [{ type: "STANDARD" }, { type: "STANDARD" }, { type: "ELITE" }, { type: "REST" }],
+      false,
+    );
+    expect(xp).toBe(15 + 15 + 35 + 0);
+  });
+
+  it("adds the win bonus only when the run was won", () => {
+    const cleared = [{ type: "STANDARD" as const }, { type: "BOSS" as const }];
+    const lostXp = calculBrainrunUserXP(cleared, false);
+    const wonXp = calculBrainrunUserXP(cleared, true);
+    expect(wonXp - lostXp).toBe(150);
+  });
+});
+
+describe("generateActChoicePoints", () => {
+  function isPure(choiceTypes: string[]) {
+    return (
+      choiceTypes.length === 2 && choiceTypes.includes("STANDARD") && choiceTypes.includes("ELITE")
+    );
+  }
+
+  it("always produces exactly one choice point per sequence slot", () => {
+    for (let i = 0; i < 50; i++) {
+      const points = generateActChoicePoints();
+      expect(points).toHaveLength(BRAINRUN_CHOICE_POINTS_PER_ACT);
+      const sequences = points.map((p) => p.sequence).sort((a, b) => a - b);
+      expect(sequences).toEqual([1, 2, 3, 4, 5, 6]);
+    }
+  });
+
+  it("respects the minimum quotas on every generated act, across many random draws", () => {
+    for (let i = 0; i < 200; i++) {
+      const points = generateActChoicePoints();
+      const pureCount = points.filter((p) => isPure(p.choiceTypes)).length;
+      const shopCount = points.filter((p) => p.choiceTypes.includes("SHOP")).length;
+      const restCount = points.filter((p) => p.choiceTypes.includes("REST")).length;
+      const eventCount = points.filter((p) => p.choiceTypes.includes("EVENT")).length;
+
+      expect(pureCount).toBeGreaterThanOrEqual(3);
+      expect(shopCount).toBeGreaterThanOrEqual(1);
+      expect(restCount).toBeGreaterThanOrEqual(1);
+      expect(eventCount).toBeGreaterThanOrEqual(2);
+
+      // Chaque point de choix mixte doit garder un vrai choix de combat (Standard ou Elite).
+      points
+        .filter((p) => !isPure(p.choiceTypes))
+        .forEach((p) => {
+          const combatOptions = p.choiceTypes.filter((t) => t === "STANDARD" || t === "ELITE");
+          expect(combatOptions).toHaveLength(1);
+        });
+    }
+  });
+
+  it("is deterministic given a fixed random source", () => {
+    const fixedRandom = () => 0.42;
+    const a = generateActChoicePoints(fixedRandom);
+    const b = generateActChoicePoints(fixedRandom);
+    expect(a).toEqual(b);
+  });
+});

--- a/server/utils/brainrunLogic.ts
+++ b/server/utils/brainrunLogic.ts
@@ -1,0 +1,121 @@
+import type { BrainrunRoomType } from "#shared/brainrun";
+import {
+  BRAINRUN_CHOICE_POINTS_PER_ACT,
+  BRAINRUN_MIN_EVENT_OFFERS,
+  BRAINRUN_MIN_PURE_COMBAT_RATIO,
+  BRAINRUN_MIN_REST_OFFERS,
+  BRAINRUN_MIN_SHOP_OFFERS,
+  BRAINRUN_ROOMS_PER_ACT,
+  BRAINRUN_TOTAL_ACTS,
+  BRAINRUN_WIN_BONUS_XP,
+  BRAINRUN_XP_BY_ROOM_TYPE,
+} from "./brainrunConfig";
+
+export function brainrunHpLossForDifficulty(difficulty: number): number {
+  if (difficulty <= 2) return 1;
+  if (difficulty <= 4) return 2;
+  return 3;
+}
+
+export function shouldEndRunOnDamage(healthPointAfter: number): boolean {
+  return healthPointAfter <= 0;
+}
+
+export function isAwaitingChoice(room: { type: string | null }): boolean {
+  return room.type === null;
+}
+
+export type NextRoomOutcome =
+  | { kind: "AWAIT_CHOICE"; act: number; sequence: number }
+  | { kind: "RUN_WON" };
+
+/** Détermine la prochaine salle à proposer une fois la salle courante (act/sequence) nettoyée. */
+export function nextRoomAfterClear(act: number, sequence: number): NextRoomOutcome {
+  if (sequence < BRAINRUN_ROOMS_PER_ACT) {
+    return { kind: "AWAIT_CHOICE", act, sequence: sequence + 1 };
+  }
+  if (act < BRAINRUN_TOTAL_ACTS) {
+    return { kind: "AWAIT_CHOICE", act: act + 1, sequence: 1 };
+  }
+  return { kind: "RUN_WON" };
+}
+
+export function instantRoomHealthDelta(type: "REST" | "SHOP" | "EVENT"): number {
+  return type === "REST" ? 1 : 0;
+}
+
+export function calculBrainrunUserXP(
+  clearedRooms: { type: "STANDARD" | "ELITE" | "BOSS" | "REST" | "SHOP" | "EVENT" }[],
+  won: boolean,
+): number {
+  const xpByType: Record<string, number> = {
+    ...BRAINRUN_XP_BY_ROOM_TYPE,
+    REST: 0,
+    SHOP: 0,
+    EVENT: 0,
+  };
+  const base = clearedRooms.reduce((sum, r) => sum + (xpByType[r.type] ?? 0), 0);
+  return won ? base + BRAINRUN_WIN_BONUS_XP : base;
+}
+
+export type BrainrunChoicePoint = {
+  sequence: number;
+  choiceTypes: BrainrunRoomType[];
+};
+
+function shuffle<T>(items: T[], random: () => number): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j] as T, copy[i] as T];
+  }
+  return copy;
+}
+
+/**
+ * Génère la forme des points de choix d'un acte (hors salle Boss finale, toujours fixe/séparée) :
+ * au moins BRAINRUN_MIN_PURE_COMBAT_RATIO de points purement [STANDARD, ELITE], et au moins
+ * une occurrence de SHOP/REST et deux de EVENT réparties sur des points distincts.
+ * `random` est injectable pour des tests déterministes (par défaut Math.random).
+ */
+export function generateActChoicePoints(random: () => number = Math.random): BrainrunChoicePoint[] {
+  const totalPoints = BRAINRUN_CHOICE_POINTS_PER_ACT;
+  const minPure = Math.ceil(totalPoints * BRAINRUN_MIN_PURE_COMBAT_RATIO);
+  const mixedCount = totalPoints - minPure;
+
+  const specialsPool: BrainrunRoomType[] = [
+    ...(Array(BRAINRUN_MIN_SHOP_OFFERS).fill("SHOP") as BrainrunRoomType[]),
+    ...(Array(BRAINRUN_MIN_REST_OFFERS).fill("REST") as BrainrunRoomType[]),
+    ...(Array(BRAINRUN_MIN_EVENT_OFFERS).fill("EVENT") as BrainrunRoomType[]),
+  ];
+
+  const buckets: BrainrunRoomType[][] = Array.from({ length: mixedCount }, () => []);
+  const shuffledSpecials = shuffle(specialsPool, random);
+  shuffledSpecials.forEach((special, i) => {
+    if (i < mixedCount) {
+      buckets[i]!.push(special);
+      return;
+    }
+    // Item excédentaire : on évite de le placer dans un bucket qui a déjà ce même type,
+    // pour garantir que EVENT (2 occurrences minimum) apparaisse sur 2 points distincts.
+    const eligible = buckets.map((_, idx) => idx).filter((idx) => !buckets[idx]!.includes(special));
+    const pickFrom = eligible.length > 0 ? eligible : buckets.map((_, idx) => idx);
+    const pick = pickFrom[Math.floor(random() * pickFrom.length)]!;
+    buckets[pick]!.push(special);
+  });
+
+  const purePoints: BrainrunChoicePoint[] = Array.from({ length: minPure }, () => ({
+    sequence: 0,
+    choiceTypes: shuffle(["STANDARD", "ELITE"], random),
+  }));
+
+  const mixedPoints: BrainrunChoicePoint[] = buckets.map((specials) => ({
+    sequence: 0,
+    choiceTypes: shuffle([random() < 0.5 ? "STANDARD" : "ELITE", ...specials], random),
+  }));
+
+  return shuffle([...purePoints, ...mixedPoints], random).map((point, index) => ({
+    ...point,
+    sequence: index + 1,
+  }));
+}

--- a/server/utils/brainrunLogic.ts
+++ b/server/utils/brainrunLogic.ts
@@ -1,4 +1,5 @@
 import type { BrainrunRoomType } from "#shared/brainrun";
+import { brainrunPotentialBossDamage, BRAINRUN_BOSS_QUESTION_TIME_MS } from "#shared/brainrun";
 import {
   BRAINRUN_CHOICE_POINTS_PER_ACT,
   BRAINRUN_MIN_EVENT_OFFERS,
@@ -42,6 +43,20 @@ export function nextRoomAfterClear(act: number, sequence: number): NextRoomOutco
 
 export function instantRoomHealthDelta(type: "REST" | "SHOP" | "EVENT"): number {
   return type === "REST" ? 1 : 0;
+}
+
+/** true dès que le temps imparti pour répondre à la question de boss est écoulé. */
+export function isBossAnswerTimedOut(elapsedMs: number): boolean {
+  return elapsedMs >= BRAINRUN_BOSS_QUESTION_TIME_MS;
+}
+
+/**
+ * Dégâts infligés au boss pour une réponse donnée : 0 si incorrecte, sinon la valeur
+ * potentielle décroissante selon le temps écoulé (cf. brainrunPotentialBossDamage, partagée
+ * avec le client qui l'utilise pour afficher l'aperçu de dégâts pendant le combat).
+ */
+export function brainrunBossDamage(elapsedMs: number, success: boolean): number {
+  return success ? brainrunPotentialBossDamage(elapsedMs) : 0;
 }
 
 export function calculBrainrunUserXP(

--- a/shared/DTO/brainrunResponseDTO.ts
+++ b/shared/DTO/brainrunResponseDTO.ts
@@ -1,0 +1,12 @@
+import type { BrainrunRoomType } from "../brainrun";
+
+export type BrainrunResponseDTO = {
+  runId: string;
+  questionId: number;
+  userResponseId: number;
+};
+
+export type BrainrunChoiceDTO = {
+  runId: string;
+  choice: BrainrunRoomType;
+};

--- a/shared/brainrun.ts
+++ b/shared/brainrun.ts
@@ -1,0 +1,55 @@
+import type { QuestionDTO } from "./question";
+
+/** Constantes de structure de run partagées entre client et serveur (affichage de la progression). */
+export const BRAINRUN_TOTAL_ACTS = 3;
+export const BRAINRUN_CHOICE_POINTS_PER_ACT = 6;
+export const BRAINRUN_ROOMS_PER_ACT = BRAINRUN_CHOICE_POINTS_PER_ACT + 1;
+
+export type BrainrunRoomType = "STANDARD" | "ELITE" | "BOSS" | "REST" | "SHOP" | "EVENT";
+export type BrainrunRoomStatus = "PENDING" | "ACTIVE" | "CLEARED" | "FAILED" | "SKIPPED";
+export type BrainrunRunStatus = "IN_PROGRESS" | "WON" | "LOST" | "ABANDONED";
+
+export type BrainrunRoomResponse = {
+  questionId: number;
+  responseId: number;
+  success: boolean;
+  /** PV perdus pour cette réponse (0 si correcte). */
+  hpLoss: number;
+};
+
+export type BrainrunRoomDTO = {
+  id: number;
+  runId: string;
+  act: number;
+  sequence: number;
+  type: BrainrunRoomType | null;
+  status: BrainrunRoomStatus;
+  choiceTypes: BrainrunRoomType[];
+  questionIds: number[];
+  responses: BrainrunRoomResponse[];
+  goldEarned: number;
+};
+
+export type BrainrunRunDTO = {
+  id: string;
+  userId: string;
+  status: BrainrunRunStatus;
+  currentAct: number;
+  currentSequence: number;
+  healthPoint: number;
+  maxHealthPoint: number;
+  gold: number;
+  xpEarned: number | null;
+  createDate: Date;
+  endDate: Date | null;
+};
+
+/** Réponse de GET /api/brainrun/current : reflète intégralement l'état courant, dérivé côté serveur. */
+export type BrainrunStateDTO = {
+  run: BrainrunRunDTO;
+  currentRoom: BrainrunRoomDTO | null;
+  /** Question à afficher si la salle active est en cours de résolution (type déjà choisi). */
+  currentQuestion: QuestionDTO | null;
+  /** true si la salle active attend un choix du joueur parmi currentRoom.choiceTypes. */
+  awaitingChoice: boolean;
+};

--- a/shared/brainrun.ts
+++ b/shared/brainrun.ts
@@ -4,6 +4,27 @@ import type { QuestionDTO } from "./question";
 export const BRAINRUN_TOTAL_ACTS = 3;
 export const BRAINRUN_CHOICE_POINTS_PER_ACT = 6;
 export const BRAINRUN_ROOMS_PER_ACT = BRAINRUN_CHOICE_POINTS_PER_ACT + 1;
+/** Temps imparti par question du combat de boss (contre-la-montre) ; le client en a besoin pour afficher le chrono. */
+export const BRAINRUN_BOSS_QUESTION_TIME_MS = 10_000;
+/** Sous ce délai de réponse (correcte), les dégâts infligés au boss sont doublés ; le client en a besoin pour afficher l'aperçu de dégâts. */
+export const BRAINRUN_BOSS_FAST_ANSWER_MS = 2_000;
+/** Dégâts infligés au boss pour une réponse correcte dans les temps (hors bonus de vitesse). */
+export const BRAINRUN_BOSS_BASE_DAMAGE = 20;
+/** Multiplicateur de dégâts appliqué en cas de réponse correcte rapide (< BRAINRUN_BOSS_FAST_ANSWER_MS). */
+export const BRAINRUN_BOSS_FAST_DAMAGE_MULTIPLIER = 2;
+
+/**
+ * Dégâts qui seraient infligés au boss si la réponse actuelle était correcte, en fonction du
+ * temps déjà écoulé sur la question — décroît de BRAINRUN_BOSS_BASE_DAMAGE * multiplicateur à 0.
+ * Utilisé côté client pour l'aperçu affiché pendant le combat, et côté serveur comme base du
+ * calcul réel des dégâts (cf. brainrunBossDamage dans server/utils/brainrunLogic.ts).
+ */
+export function brainrunPotentialBossDamage(elapsedMs: number): number {
+  if (elapsedMs >= BRAINRUN_BOSS_QUESTION_TIME_MS) return 0;
+  return elapsedMs < BRAINRUN_BOSS_FAST_ANSWER_MS
+    ? BRAINRUN_BOSS_BASE_DAMAGE * BRAINRUN_BOSS_FAST_DAMAGE_MULTIPLIER
+    : BRAINRUN_BOSS_BASE_DAMAGE;
+}
 
 export type BrainrunRoomType = "STANDARD" | "ELITE" | "BOSS" | "REST" | "SHOP" | "EVENT";
 export type BrainrunRoomStatus = "PENDING" | "ACTIVE" | "CLEARED" | "FAILED" | "SKIPPED";
@@ -15,6 +36,10 @@ export type BrainrunRoomResponse = {
   success: boolean;
   /** PV perdus pour cette réponse (0 si correcte). */
   hpLoss: number;
+  /** Dégâts infligés au boss pour cette réponse (uniquement salle BOSS, 0 sinon). */
+  bossDamage?: number;
+  /** true si le temps imparti a expiré avant la réponse (uniquement salle BOSS). */
+  timedOut?: boolean;
 };
 
 export type BrainrunRoomDTO = {
@@ -28,6 +53,12 @@ export type BrainrunRoomDTO = {
   questionIds: number[];
   responses: BrainrunRoomResponse[];
   goldEarned: number;
+  /** PV courants du boss (uniquement salle BOSS active/terminée, null sinon). */
+  bossHealthPoint: number | null;
+  /** PV max du boss au démarrage du combat (uniquement salle BOSS, null sinon). */
+  bossMaxHealthPoint: number | null;
+  /** Horodatage limite pour répondre à la question en cours (uniquement salle BOSS active). */
+  questionDeadline: Date | null;
 };
 
 export type BrainrunRunDTO = {


### PR DESCRIPTION
## Summary
- New "Brainrun" game mode: roguelite-style run across 3 acts, sequential choice-driven rooms (STANDARD/ELITE/BOSS/REST/SHOP/EVENT combat), HP loss on wrong answers, gold/XP rewards.
- Boss fights: timed questions (contre-la-montre), boss HP bar, damage scaling with answer speed — the fight now only ends when the boss reaches exactly 0 HP, with no cap on the number of questions asked.
- Menu entry hidden (`app/layouts/default.vue`) — the mode is only reachable via `/series/brainrun` while still in progress (not yet feature-complete: SHOP/EVENT rooms are placeholders).

## Test plan
- [x] `vp check` (lint/format/typecheck) passes with no new errors
- [x] Brainrun unit tests reviewed (`server/utils/brainrunLogic.test.ts`) — pre-existing Vitest module-alias failure unrelated to this change
- [ ] Manual run-through in browser (choice flow, combat rooms, boss fight down to 0 HP, run win/loss) — not yet verified by a human tester

🤖 Generated with [Claude Code](https://claude.com/claude-code)